### PR TITLE
Add purge_configdir to purge old configs

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,10 +7,12 @@ class logrotate::config{
   $config            = $::logrotate::config
 
   file{ $::logrotate::rules_configdir:
-    ensure => directory,
-    owner  => $logrotate::root_user,
-    group  => $logrotate::root_group,
-    mode   => '0755',
+    ensure  => directory,
+    owner   => $logrotate::root_user,
+    group   => $logrotate::root_group,
+    purge   => $::logrotate::purge_configdir,
+    recurse => $::logrotate::purge_configdir,
+    mode    => '0755',
   }
 
   if $manage_cron_daily {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class logrotate (
   Logrotate::Ensurable $ensure       = present,
   Boolean $hieramerge                = false,
   Boolean $manage_cron_daily         = true,
+  Boolean $purge_configdir           = false,
   String $package                    = 'logrotate',
   Hash $rules                        = {},
   Optional[String] $config           = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -41,6 +41,19 @@ describe 'logrotate' do
             is_expected.to contain_class('logrotate::defaults')
           end
         end
+
+        context 'logrotate class with purge_configdir set to true' do
+          let(:params) { { purge_configdir: true } }
+
+          it do
+            is_expected.to contain_file('/etc/logrotate.d').with('ensure'  => 'directory',
+                                                                 'owner'   => 'root',
+                                                                 'group'   => 'root',
+                                                                 'mode'    => '0755',
+                                                                 'purge'   => true,
+                                                                 'recurse' => true)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Remove unwanted config files from configdir. Has to be enabled using 

`logrotate::purge_configdir: true`
