### PR TITLE
add option to extend list of paths

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class logrotate (
   $package            = 'logrotate',
   $rules              = {},
   $config             = undef,
+  $use_concat         = false,
   $cron_daily_hour    = $logrotate::params::cron_daily_hour,
   $cron_daily_minute  = $logrotate::params::cron_daily_minute,
   $cron_hourly_minute = $logrotate::params::cron_hourly_minute,

--- a/manifests/rulepath.pp
+++ b/manifests/rulepath.pp
@@ -1,0 +1,23 @@
+define logrotate::rulepath (
+  $rule = undef,
+  $order = "01",
+  $hourly = false,
+  $path = undef,
+) {
+
+  if (is_array($path)) {
+    $rpath = join($path, " ")
+  } else {
+    $rpath = $path
+  }
+  if ($hourly) {
+    $rule_path = "/etc/logrotate.d/hourly/${rule}"
+  } else {
+    $rule_path = "/etc/logrotate.d/${rule}"
+  }
+  concat::fragment { $name:
+    target => $rule_path,
+    order => $order,
+    content => "$rpath ",
+  }
+}

--- a/manifests/rulepath.pp
+++ b/manifests/rulepath.pp
@@ -1,12 +1,12 @@
 define logrotate::rulepath (
   $rule = undef,
-  $order = "01",
+  $order = '01',
   $hourly = false,
   $path = undef,
 ) {
 
   if (is_array($path)) {
-    $rpath = join($path, " ")
+    $rpath = join($path, ' ')
   } else {
     $rpath = $path
   }
@@ -16,8 +16,8 @@ define logrotate::rulepath (
     $rule_path = "/etc/logrotate.d/${rule}"
   }
   concat::fragment { $name:
-    target => $rule_path,
-    order => $order,
-    content => "$rpath ",
+    target  => $rule_path,
+    order   => $order,
+    content => "${rpath} ",
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 <5.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 1.1.1 <3.0.0"
     }
   ],
   "requirements": [

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -1229,8 +1229,9 @@ describe 'logrotate::rule' do
         operatingsystemmajrelease: 7
       }
     end
+
     it do
-      should contain_file('/etc/logrotate.d/btmp').without_content(%r{/ifempty/})
+      is_expected.to contain_file('/etc/logrotate.d/btmp').without_content(%r{/ifempty/})
     end
   end
 end

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -1,6 +1,8 @@
+<%- if !@_use_concat -%>
 # THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.  ANY CHANGES WILL BE
 # OVERWRITTEN.
 
+<%- end -%>
 <%
   opts = []
 


### PR DESCRIPTION
If there is interest in this change I will add tests and documentation. We use this to add additional logfiles to existing rules. Here is an example:

```
rsyslog::snippet { '31-haproxy':
  content => @("EOF"/$)
    \$AddUnixListenSocket $chroot/dev/log

    if \$programname startswith 'haproxy' then /var/log/haproxy/haproxy.log
    &~
    | EOF
}
logrotate::rulepath { 'syslog-haproxy':
  rule => 'syslog',
  path => '/var/log/haproxy/haproxy.log',
}
```
