### PR TITLE
Default added for config, so we can just use contain logrotate.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class logrotate (
   $manage_cron_daily  = true,
   $package            = 'logrotate',
   $rules              = {},
-  $config             = undef,
+  $config             = {},
   $cron_daily_hour    = $logrotate::params::cron_daily_hour,
   $cron_daily_minute  = $logrotate::params::cron_daily_minute,
   $cron_hourly_minute = $logrotate::params::cron_hourly_minute,


### PR DESCRIPTION
Default added for config, so we can just use ```contain logrotate```.

<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->