### PR TITLE
Make the creation of default [bw]tmp-rulesets configurable

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -1,8 +1,9 @@
 # apply defaults
 #
 class logrotate::defaults (
-  $rules        = $logrotate::params::base_rules,
-  $rule_default = $logrotate::params::rule_default
+  $create_base_rules = $logrotate::create_base_rules,
+  $rules             = $logrotate::params::base_rules,
+  $rule_default      = $logrotate::params::rule_default
 ){
 
   assert_private()
@@ -13,11 +14,13 @@ class logrotate::defaults (
     }
   }
 
-  $rules.each |$rule_name, $params| {
-    if !defined(Logrotate::Rule[$rule_name]) {
-      $_merged_params = merge($rule_default,$params)
-      logrotate::rule{ $rule_name:
-        * => $_merged_params,
+  if $create_base_rules {
+    $rules.each |$rule_name, $params| {
+      if !defined(Logrotate::Rule[$rule_name]) {
+        $_merged_params = merge($rule_default,$params)
+        logrotate::rule{ $rule_name:
+          * => $_merged_params,
+        }
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class logrotate (
   String $ensure                     = present,
   Boolean $hieramerge                = false,
   Boolean $manage_cron_daily         = true,
+  Boolean $create_base_rules         = true,
   Boolean $purge_configdir           = false,
   String $package                    = 'logrotate',
   Hash $rules                        = {},

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -62,6 +62,15 @@ describe 'logrotate' do
                                                                  'recurse' => true)
           end
         end
+
+        context 'logrotate class with create_base_rules set to to false' do
+          let(:params) { { create_base_rules: false } }
+
+          it do
+            is_expected.not_to contain_logrotate__rule('btmp')
+            is_expected.not_to contain_logrotate__rule('wtmp')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
As I'm configuring the rules for btmp and wtmp on my own, the default rulesets conflict with my rules.
With this change you can disable the generation of the default rules like this:

```
class { '::logrotate':
  defaultrule_bwtmp => false,
}
```