### PR TITLE
Added support for dateyesterday within logrotate::rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ dateext         - A Boolean specifying whether rotated log files should be
                   (optional).
 dateformat      - The format String to be used for `dateext` (optional).
                   Valid specifiers are '%Y', '%m', '%d' and '%s'.
+dateyesterday   - A Boolean specifying whether to use yesterday's date instead
+                  of today's date to create the `dateext` extension (optional).
 delaycompress   - A Boolean specifying whether compression of the rotated
                   log file should be delayed until the next logrotate run
                   (optional).

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -29,6 +29,8 @@
 #                   (optional).
 # dateformat      - The format String to be used for `dateext` (optional).
 #                   Valid specifiers are '%Y', '%m', '%d' and '%s'.
+# dateyesterday   - A Boolean specifying whether to use yesterday's date instead
+#                   of today's date to create the `dateext` extension (optional).
 # delaycompress   - A Boolean specifying whether compression of the rotated
 #                   log file should be delayed until the next logrotate run
 #                   (optional).
@@ -137,6 +139,7 @@ define logrotate::rule(
   Optional[String] $create_group                    = undef,
   Optional[Boolean] $dateext                        = undef,
   Optional[String] $dateformat                      = undef,
+  Optional[Boolean] $dateyesterday                  = undef,
   Optional[Boolean] $delaycompress                  = undef,
   Optional[String] $extension                       = undef,
   Optional[Boolean] $ifempty                        = undef,

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -205,6 +205,42 @@ describe 'logrotate::rule' do
     end
 
     ###########################################################################
+    # DATEYESTERDAY
+    context 'and dateyesterday => true' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :dateyesterday => true}
+      }
+
+      it do
+        should contain_file('/etc/logrotate.d/test') \
+          .with_content(/^  dateyesterday$/)
+      end
+    end
+
+    context 'and dateyesterday => false' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :dateyesterday => false}
+      }
+
+      it do
+        should contain_file('/etc/logrotate.d/test') \
+          .without_content(/^  dateyesterday$/)
+      end
+    end
+
+    context 'and dateyesterday => foo' do
+      let(:params) {
+        {:path => '/var/log/foo.log', :dateyesterday => 'foo'}
+      }
+
+      it do
+        expect {
+          should contain_file('/etc/logrotate.d/test')
+        }.to raise_error(Puppet::Error, /dateyesterday must be a boolean/)
+      end
+    end
+
+    ###########################################################################
     # EXTENSION
     context 'and extension => foo' do
       let(:params) { { path: '/var/log/foo.log', extension: '.foo' } }

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -205,42 +205,6 @@ describe 'logrotate::rule' do
     end
 
     ###########################################################################
-    # DATEYESTERDAY
-    context 'and dateyesterday => true' do
-      let(:params) {
-        {:path => '/var/log/foo.log', :dateyesterday => true}
-      }
-
-      it do
-        should contain_file('/etc/logrotate.d/test') \
-          .with_content(/^  dateyesterday$/)
-      end
-    end
-
-    context 'and dateyesterday => false' do
-      let(:params) {
-        {:path => '/var/log/foo.log', :dateyesterday => false}
-      }
-
-      it do
-        should contain_file('/etc/logrotate.d/test') \
-          .without_content(/^  dateyesterday$/)
-      end
-    end
-
-    context 'and dateyesterday => foo' do
-      let(:params) {
-        {:path => '/var/log/foo.log', :dateyesterday => 'foo'}
-      }
-
-      it do
-        expect {
-          should contain_file('/etc/logrotate.d/test')
-        }.to raise_error(Puppet::Error, /dateyesterday must be a boolean/)
-      end
-    end
-
-    ###########################################################################
     # EXTENSION
     context 'and extension => foo' do
       let(:params) { { path: '/var/log/foo.log', extension: '.foo' } }
@@ -625,7 +589,7 @@ describe 'logrotate::rule' do
     %w[minsize maxsize size].each do |param|
       it_behaves_like 'logrotate::size', param
     end
-    %w[compress copy copytruncate create dateext delaycompress ifempty missingok sharedscripts shred].each do |param|
+    %w[compress copy copytruncate create dateext delaycompress ifempty missingok sharedscripts shred dateyesterday].each do |param|
       it_behaves_like 'boolean flag', param
     end
     %w[maxage rotate shredcycles start].each do |param|

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -19,7 +19,7 @@
   end
 
   %w(compress copy copytruncate delaycompress
-  dateext missingok sharedscripts shred).each do |bool_opt|
+  dateext missingok sharedscripts shred dateyesterday).each do |bool_opt|
     if (scope.to_hash.has_key?(bool_opt) && scope.to_hash[bool_opt] != nil)
       opts << (scope.to_hash[bool_opt] == true ? '' : 'no') + bool_opt
     end


### PR DESCRIPTION
Added support for dateyesterday to be used within logrotate rules.

Previous done against the original code by another author.
https://github.com/rodjek/puppet-logrotate/pull/53/files

Adapted those changes to the latest version of the module.