### PR TITLE
use logrotate::cron instead of a broken file resource

### DIFF
--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -27,12 +27,5 @@ class logrotate::hourly (
     group  => 'root',
     mode   => '0755',
   }
-  file { $logrotate::cron_hourly_file:
-    ensure  => $ensure,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0555',
-    source  => 'puppet:///modules/logrotate/etc/cron.hourly/logrotate',
-    require => [File["${logrotate::rules_configdir}/hourly"],Package['logrotate']],
-  }
+  logrotate::cron { 'hourly': }
 }


### PR DESCRIPTION
Use _logrorate::cron_ instead of a file resource that tries to use a file that has not been around since module version _1.4.0_.

This resolves the error when including _logrotate::hourly_;
`Error: /Stage[main]/Logrotate::Hourly/File[/etc/cron.hourly/logrotate]: Could not evaluate: Could not retrieve information from environment production source(s) puppet:///modules/logrotate/etc/cron.hourly/logrotate`
