### PR TITLE
wrong datatype for $config, s/String/Hash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class logrotate (
   Boolean $manage_cron_daily         = true,
   String $package                    = 'logrotate',
   Hash $rules                        = {},
-  Optional[String] $config           = undef,
+  Optional[Hash] $config             = undef,
   Integer[0,23] $cron_daily_hour     = $logrotate::params::cron_daily_hour,
   Integer[0,59] $cron_daily_minute   = $logrotate::params::cron_daily_minute,
   Integer[0,59] $cron_hourly_minute  = $logrotate::params::cron_hourly_minute,


### PR DESCRIPTION
This was always a Hash, as you can see in the README.md, String never work. So the next release should be a patch release, not a major one.

----

This Commit is presented to you by Lufthansa