### PR TITLE
Removed the !defined logic as the variable su_user and su_group are d…

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -22,6 +22,7 @@ define logrotate::conf (
   Optional[String] $create_group                     = undef,
   Optional[Boolean] $dateext                         = undef,
   Optional[String] $dateformat                       = undef,
+  Optional[Boolean] $dateyesterday                   = undef,
   Optional[Boolean] $delaycompress                   = undef,
   Optional[String] $extension                        = undef,
   Optional[Boolean] $ifempty                         = undef,

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -69,15 +69,13 @@ define logrotate::conf (
     }
   }
 
-  if $su_user and !defined('$su_group') {
-    $_su_user  = $su_user
-    $_su_group = 'root'
-  } elsif !defined('$su_user') and $su_group {
-    $_su_user  = 'root'
-    $_su_group = $su_group
-  } else {
-    $_su_user  = $su_user
-    $_su_group = $su_group
+  $_su_user = $su_user ? {
+    undef    => 'root',
+    default  => $su_user,
+  }
+  $_su_group = $su_group ? {
+    undef   => 'root',
+    default => $su_group,
   }
 
   if $create_group and !$create_owner {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class logrotate::params {
       $root_group    = 'wheel'
       $logrotate_bin = '/usr/local/sbin/logrotate'
       $conf_params = {
-        su_group => $default_su_group,
+        su_group => undef,
       }
       $base_rules = {
         'wtmp' => {

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -210,15 +210,13 @@ define logrotate::rule(
     fail("Logrotate::Rule[${rulename}]: create_mode requires create")
   }
 
-  if $su_owner and !defined('$su_group') {
-    $_su_owner = $su_owner
-    $_su_group = 'root'
-  } elsif !defined('$su_owner') and $su_group {
-    $_su_owner = 'root'
-    $_su_group = $su_group
-  } else {
-    $_su_owner = $su_owner
-    $_su_group = $su_group
+  $_su_user = $su_user ? {
+    undef    => 'root',
+    default  => $su_user,
+  }
+  $_su_group = $su_group ? {
+    undef   => 'root',
+    default => $su_group,
   }
 
   #############################################################################

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -93,7 +93,7 @@
 # su              - A Boolean specifying whether logrotate should rotate under
 #                   the specific su_owner and su_group instead of the default.
 #                   First available in logrotate 3.8.0. (optional)
-# su_owner        - A username String that logrotate should use to rotate a
+# su_user         - A String username that logrotate should use to rotate a
 #                   log file set instead of using the default if
 #                   su => true (optional).
 # su_group        - A String group name that logrotate should use to rotate a
@@ -162,7 +162,7 @@ define logrotate::rule(
   Optional[Integer] $shredcycles                    = undef,
   Optional[Integer] $start                          = undef,
   Optional[Boolean] $su                             = undef,
-  Optional[Logrotate::UserOrGroup] $su_owner        = undef,
+  Optional[Logrotate::UserOrGroup] $su_user         = undef,
   Optional[Logrotate::UserOrGroup] $su_group        = undef,
   Optional[String] $uncompresscmd                   = undef
 ) {
@@ -217,9 +217,10 @@ define logrotate::rule(
   }
 
   $_su_user = $su_user ? {
-    undef    => 'root',
-    default  => $su_user,
+    undef   => 'root',
+    default => $su_user,
   }
+
   $_su_group = $su_group ? {
     undef   => 'root',
     default => $su_group,

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -161,6 +161,7 @@ define logrotate::rule(
   Optional[Boolean] $shred                          = undef,
   Optional[Integer] $shredcycles                    = undef,
   Optional[Integer] $start                          = undef,
+  Optional[Boolean] $su                             = undef,
   Optional[Logrotate::UserOrGroup] $su_owner        = undef,
   Optional[Logrotate::UserOrGroup] $su_group        = undef,
   Optional[String] $uncompresscmd                   = undef
@@ -208,6 +209,11 @@ define logrotate::rule(
 
   if ($create_mode != undef) and ($create != true) {
     fail("Logrotate::Rule[${rulename}]: create_mode requires create")
+  }
+
+  $_su = $su ? {
+    undef   => false,
+    default => $su,
   }
 
   $_su_user = $su_user ? {

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -140,10 +140,8 @@ describe 'logrotate::conf' do
     context 'su_user => undef' do
       context 'su_group => root' do
         let(:params) do
-          {
-            su_user: :undef,
-            su_group: 'root'
-          }
+          { su_user: :undef,
+            su_group: 'root' }
         end
         it {
           is_expected.to contain_file('/etc/logrotate.conf').
@@ -155,10 +153,8 @@ describe 'logrotate::conf' do
     context 'su_user => root' do
       context 'su_group => undef' do
         let(:params) do
-          {
-            su_user: 'root',
-            su_group: :undef
-          }
+          { su_user: 'root',
+            su_group: :undef }
         end
         it {
           is_expected.to contain_file('/etc/logrotate.conf').

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -124,6 +124,49 @@ describe 'logrotate::conf' do
       }
     end
 
+    context 'su_user => root' do
+      context 'su_group => root' do
+        let(:params) do
+          { su_user: 'root',
+            su_group: 'root' }
+        end
+        it {
+          is_expected.to contain_file('/etc/logrotate.conf').
+            with_content(%r{^su root root$})
+        }
+      end
+    end
+
+    context 'su_user => undef' do
+      conext 'su_group => root' do
+        let(:params) do
+          {
+            su_user: :undef,
+            su_group: 'root'
+          }
+        end
+        it {
+          is_expected.to contain_file('/etc/logrotate.conf').
+            with_content(%r{^su root root$})
+        }
+      end
+    end
+
+    context 'su_user => root' do
+      conext 'su_group => undef' do
+        let(:params) do
+          {
+            su_user: 'root',
+            su_group: :undef
+          }
+        end
+        it {
+          is_expected.to contain_file('/etc/logrotate.conf').
+            with_content(%r{^su root root$})
+        }
+      end
+    end
+
     context 'compressext => .bz2' do
       let(:params) { { compressext: '.bz2' } }
 

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -130,6 +130,7 @@ describe 'logrotate::conf' do
           { su_user: 'root',
             su_group: 'root' }
         end
+
         it {
           is_expected.to contain_file('/etc/logrotate.conf').
             with_content(%r{^su root root$})
@@ -143,6 +144,7 @@ describe 'logrotate::conf' do
           { su_user: :undef,
             su_group: 'root' }
         end
+
         it {
           is_expected.to contain_file('/etc/logrotate.conf').
             with_content(%r{^su root root$})
@@ -156,6 +158,7 @@ describe 'logrotate::conf' do
           { su_user: 'root',
             su_group: :undef }
         end
+
         it {
           is_expected.to contain_file('/etc/logrotate.conf').
             with_content(%r{^su root root$})

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -138,7 +138,7 @@ describe 'logrotate::conf' do
     end
 
     context 'su_user => undef' do
-      conext 'su_group => root' do
+      context 'su_group => root' do
         let(:params) do
           {
             su_user: :undef,
@@ -153,7 +153,7 @@ describe 'logrotate::conf' do
     end
 
     context 'su_user => root' do
-      conext 'su_group => undef' do
+      context 'su_group => undef' do
         let(:params) do
           {
             su_user: 'root',

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -356,7 +356,7 @@ describe 'logrotate::conf' do
     end
 
     # Boolean Flag values
-    %w[compress copy copytruncate create dateext delaycompress ifempty missingok sharedscripts shred].each do |param|
+    %w[compress copy copytruncate create dateext delaycompress ifempty missingok sharedscripts shred dateyesterday].each do |param|
       it_behaves_like 'boolean flag', param, param != 'create'
     end
 

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -537,7 +537,6 @@ describe 'logrotate::rule' do
     ###########################################################################
     # SU / SU_OWNER / SU_GROUP
     context 'su => true' do
-
       # su is true and both user and group params are passed
       context 'su_user => www-data and su_group => admin' do
         let(:params) do
@@ -561,7 +560,7 @@ describe 'logrotate::rule' do
           {
             path: '/var/log/foo.log',
             su: true,
-            su_user: 'www-data',
+            su_user: 'www-data'
           }
         end
 
@@ -577,7 +576,7 @@ describe 'logrotate::rule' do
           {
             path: '/var/log/foo.log',
             su: true,
-            su_group: 'admin',
+            su_group: 'admin'
           }
         end
 

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -536,24 +536,12 @@ describe 'logrotate::rule' do
 
     ###########################################################################
     # SU / SU_OWNER / SU_GROUP
-    context 'and su => true' do
-      context 'and su_owner => www-data' do
-        let(:params) do
-          {
-            path: '/var/log/foo.log',
-            su_owner: 'www-data'
-          }
-        end
-
-        it {
-          is_expected.to contain_file('/etc/logrotate.d/test').
-            with_content(%r{^  su www-data})
-        }
-      end
+    context 'su => true' do
       context 'su_owner => www-data and su_group => admin' do
         let(:params) do
           {
             path: '/var/log/foo.log',
+            su: true,
             su_owner: 'www-data',
             su_group: 'admin'
           }
@@ -566,8 +554,22 @@ describe 'logrotate::rule' do
       end
     end
 
-    context 'and no su_x settings' do
-      let(:params) { { path: '/var/log/foo.log' } }
+    context 'su => false' do
+      let(:params) { { su: false } }
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.d/test').
+          without_content(%r{^\s+su\s})
+      }
+    end
+
+    context 'su => undef' do
+      let(:params) do
+        {
+          path: '/var/log/foo.log',
+          su: :undef
+        }
+      end
 
       it {
         is_expected.to contain_file('/etc/logrotate.d/test').

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -537,12 +537,14 @@ describe 'logrotate::rule' do
     ###########################################################################
     # SU / SU_OWNER / SU_GROUP
     context 'su => true' do
-      context 'su_owner => www-data and su_group => admin' do
+
+      # su is true and both user and group params are passed
+      context 'su_user => www-data and su_group => admin' do
         let(:params) do
           {
             path: '/var/log/foo.log',
             su: true,
-            su_owner: 'www-data',
+            su_user: 'www-data',
             su_group: 'admin'
           }
         end
@@ -552,8 +554,40 @@ describe 'logrotate::rule' do
             with_content(%r{^  su www-data admin$})
         }
       end
-    end
 
+      # su is true and only user param is passed
+      context 'su_user => www-data' do
+        let(:params) do
+          {
+            path: '/var/log/foo.log',
+            su: true,
+            su_user: 'www-data',
+          }
+        end
+
+        it {
+          is_expected.to contain_file('/etc/logrotate.d/test').
+            with_content(%r{^\s+su www-data root$})
+        }
+      end
+
+      # su is true and only group param is passed
+      context 'su_group => admin' do
+        let(:params) do
+          {
+            path: '/var/log/foo.log',
+            su: true,
+            su_group: 'admin',
+          }
+        end
+
+        it {
+          is_expected.to contain_file('/etc/logrotate.d/test').
+            with_content(%r{^\s+su root admin$})
+        }
+      end
+
+    # su is false doesn't matter if user or group params are passed
     context 'su => false' do
       let(:params) { { su: false } }
 
@@ -563,6 +597,7 @@ describe 'logrotate::rule' do
       }
     end
 
+    # su param is not passed
     context 'su => undef' do
       let(:params) do
         {

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -585,7 +585,6 @@ describe 'logrotate::rule' do
             with_content(%r{^\s+su root admin$})
         }
       end
-
     end
 
     # su is false doesn't matter if user or group params are passed

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -587,6 +587,8 @@ describe 'logrotate::rule' do
         }
       end
 
+    end
+
     # su is false doesn't matter if user or group params are passed
     context 'su => false' do
       let(:params) { { su: false } }

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -589,7 +589,12 @@ describe 'logrotate::rule' do
 
     # su is false doesn't matter if user or group params are passed
     context 'and su => false' do
-      let(:params) { { su: false } }
+      let(:params) do
+        {
+          path: '/var/log/foo.log',
+          su: false
+        }
+      end
 
       it {
         is_expected.to contain_file('/etc/logrotate.d/test').

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -536,9 +536,9 @@ describe 'logrotate::rule' do
 
     ###########################################################################
     # SU / SU_OWNER / SU_GROUP
-    context 'su => true' do
+    context 'and su => true' do
       # su is true and both user and group params are passed
-      context 'su_user => www-data and su_group => admin' do
+      context 'and su_user => www-data and su_group => admin' do
         let(:params) do
           {
             path: '/var/log/foo.log',
@@ -555,7 +555,7 @@ describe 'logrotate::rule' do
       end
 
       # su is true and only user param is passed
-      context 'su_user => www-data' do
+      context 'and su_user => www-data' do
         let(:params) do
           {
             path: '/var/log/foo.log',
@@ -571,7 +571,7 @@ describe 'logrotate::rule' do
       end
 
       # su is true and only group param is passed
-      context 'su_group => admin' do
+      context 'and su_group => admin' do
         let(:params) do
           {
             path: '/var/log/foo.log',
@@ -589,7 +589,7 @@ describe 'logrotate::rule' do
     end
 
     # su is false doesn't matter if user or group params are passed
-    context 'su => false' do
+    context 'and su => false' do
       let(:params) { { su: false } }
 
       it {
@@ -599,7 +599,7 @@ describe 'logrotate::rule' do
     end
 
     # su param is not passed
-    context 'su => undef' do
+    context 'and su => undef' do
       let(:params) do
         {
           path: '/var/log/foo.log',

--- a/templates/etc/logrotate.conf.erb
+++ b/templates/etc/logrotate.conf.erb
@@ -18,7 +18,7 @@
   end
 
   %w(compress copy copytruncate delaycompress
-  dateext missingok sharedscripts shred).each do |bool_opt|
+  dateext missingok sharedscripts shred dateyesterday).each do |bool_opt|
     if (scope.to_hash.has_key?(bool_opt) && scope.to_hash[bool_opt] != nil)
       opts << (scope.to_hash[bool_opt] == true ? '':'no') + bool_opt
     end

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -44,8 +44,8 @@
   <%= opt %>
 <% end -%>
 <% if @_su == true -%>
-<% if @_su_owner != nil and @_su_group != nil -%>
-  su <%= @_su_owner %> <%= @_su_group %>
+<% if @_su_user != nil and @_su_group != nil -%>
+  su <%= @_su_user %> <%= @_su_group %>
 <% end -%>
 <% end -%>
 <% if @postrotate != nil -%>

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -43,8 +43,10 @@
 <% opts.each do |opt| -%>
   <%= opt %>
 <% end -%>
-<% if @su_owner != nil or @su_group != nil -%>
+<% if @_su == true -%>
+<% if @_su_owner != nil and @_su_group != nil -%>
   su <%= @_su_owner %> <%= @_su_group %>
+<% end -%>
 <% end -%>
 <% if @postrotate != nil -%>
   postrotate


### PR DESCRIPTION
The existing code was using defined() to determine if $su_user and $su_group were defined or not. 

The variables are parameters of the class with default values of undef. 

A variable that has been set to undef is defined, and has a value of undef.

So the code thought $su_user was defined and took its value and placed it into $_su_user, it value being in fact was undef.

This meant that the template which checks for both $_su_user and $_su_group being defined before including the 'su' directive in logrotate.conf failed because the way in which puppet code and ruby code check for whether a variable is defined are different. So ruby was determining that $_su_user was in fact undefined and didn't include the 'su' directive.

This isn't specific to Ubuntu 16.04 but fixes issue #59 I believe.

Switched the code to use selectors which specifically check $su_user and $su_group for having a value of undef or not.

Selectors were used to make it consistent with the other code in the class.
