### PR TITLE
Fix "Puppet Unknown variable: 'default_su_group'"

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class logrotate::params {
       $root_group    = 'wheel'
       $logrotate_bin = '/usr/local/sbin/logrotate'
       $conf_params = {
-        su_group => $default_su_group,
+        su_group => undef,
       }
       $base_rules = {
         'wtmp' => {


### PR DESCRIPTION
The Variable $default_su_group is not there for osfamily Freebsd. Puppet will fail if you have strict variable checking on.
