### PR TITLE
Allowed dateyesterday at the global level

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -22,6 +22,7 @@ define logrotate::conf (
   Optional[String] $create_group                     = undef,
   Optional[Boolean] $dateext                         = undef,
   Optional[String] $dateformat                       = undef,
+  Optional[Boolean] $dateyesterday                   = undef,
   Optional[Boolean] $delaycompress                   = undef,
   Optional[String] $extension                        = undef,
   Optional[Boolean] $ifempty                         = undef,

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -356,7 +356,7 @@ describe 'logrotate::conf' do
     end
 
     # Boolean Flag values
-    %w[compress copy copytruncate create dateext delaycompress ifempty missingok sharedscripts shred].each do |param|
+    %w[compress copy copytruncate create dateext delaycompress ifempty missingok sharedscripts shred dateyesterday].each do |param|
       it_behaves_like 'boolean flag', param, param != 'create'
     end
 

--- a/templates/etc/logrotate.conf.erb
+++ b/templates/etc/logrotate.conf.erb
@@ -18,7 +18,7 @@
   end
 
   %w(compress copy copytruncate delaycompress
-  dateext missingok sharedscripts shred).each do |bool_opt|
+  dateext missingok sharedscripts shred dateyesterday).each do |bool_opt|
     if (scope.to_hash.has_key?(bool_opt) && scope.to_hash[bool_opt] != nil)
       opts << (scope.to_hash[bool_opt] == true ? '':'no') + bool_opt
     end


### PR DESCRIPTION
Allows the setting of dateyesterday globally within logrotate.conf rather than in a specific rule like my last pull request.