### PR TITLE
Add missing $maxsize option to Logrotate::Conf

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -30,6 +30,7 @@ define logrotate::conf (
   Optional[Enum['mailfirst', 'maillast']] $mail_when = undef,
   Optional[Integer] $maxage                          = undef,
   Optional[Logrotate::Size] $minsize                 = undef,
+  Optional[Logrotate::Size] $maxsize                 = undef,
   Optional[Boolean] $missingok                       = undef,
   Optional[Variant[Boolean,String]] $olddir          = undef,
   Optional[String] $postrotate                       = undef,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
This PR re-adds the missing ``$maxsize`` option to ``Logrotate::Conf``. This was regressed during a refactor - see https://github.com/voxpupuli/puppet-logrotate/issues/49. 

I have *only* added this line and *not* tested this as I was not able to get set up for testing this (I ran into gem dependency conflicts).
