### PR TITLE
Remove obsolete su parameter in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,6 @@ shredcycles     - The Integer number of times shred should overwrite log files
                   before unlinking them (optional).
 start           - The Integer number to be used as the base for the extensions
                   appended to the rotated log files (optional).
-su              - A Boolean specifying whether logrotate should rotate under
-                  the specific su_owner and su_group instead of the default.
-                  First available in logrotate 3.8.0. (optional)
 su_owner        - A username String that logrotate should use to rotate a
                   log file set instead of using the default if
                   su => true (optional).

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -90,9 +90,6 @@
 #                   before unlinking them (optional).
 # start           - The Integer number to be used as the base for the extensions
 #                   appended to the rotated log files (optional).
-# su              - A Boolean specifying whether logrotate should rotate under
-#                   the specific su_owner and su_group instead of the default.
-#                   First available in logrotate 3.8.0. (optional)
 # su_owner        - A username String that logrotate should use to rotate a
 #                   log file set instead of using the default if
 #                   su => true (optional).


### PR DESCRIPTION
The su parameter was removed from the classes and templates in favor of su_owner and su_group.
