### PR TITLE
Fix missing su line in default logrotate.conf on Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,11 +31,16 @@ class logrotate::params {
       }
     }
     'Debian': {
-      $default_su_group = versioncmp($::operatingsystemmajrelease, '14.00') ? {
+      $default_su_user = versioncmp($facts['operatingsystemmajrelease'], '14.00') ? {
+        1        => 'root',
+        default  => undef,
+      }
+      $default_su_group = versioncmp($facts['operatingsystemmajrelease'], '14.00') ? {
         1         => 'syslog',
         default   => undef
       }
       $conf_params = {
+        su_user  => $default_su_user,
         su_group => $default_su_group,
       }
       $configdir     = '/etc'

--- a/spec/classes/defaults_spec.rb
+++ b/spec/classes/defaults_spec.rb
@@ -16,11 +16,17 @@ describe 'logrotate' do
 
       if facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease].to_i >= 14
         it {
-          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with_su_group('syslog')
+          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
+            'su_user' => 'root',
+            'su_group' => 'syslog'
+          )
         }
       else
         it {
-          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with_su_group(nil)
+          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
+            'su_user' => nil,
+            'su_group' => nil
+          )
         }
       end
       it {


### PR DESCRIPTION
Hi voxpopuli team,

Default /etc/logrotate.conf on Ubuntu includes a line containing 'su root syslog', but this line is not present in default config produced by this module.
Although $su_group is properly set to 'syslog' in manifests/config.pp, $su_user stays undefined and the condition in templates/etc/logrotate.conf.erb:46 is not met.

This commit makes sure $su_user is set properly on Ubuntu resulting in missing line being present in default config file.

Cheers
Grzegorz