### PR TITLE
closes #40, ::conf params should be identitical to ::rule params.

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -43,7 +43,7 @@ define logrotate::conf (
   Optional[Boolean] $shred                           = undef,
   Optional[Integer] $shredcycles                     = undef,
   Optional[Integer] $start                           = undef,
-  Optional[Logrotate::UserOrGroup] $su_user          = undef,
+  Optional[Logrotate::UserOrGroup] $su_owner         = undef,
   Optional[Logrotate::UserOrGroup] $su_group         = undef,
   Optional[String] $uncompresscmd                    = undef
 ) {

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -69,14 +69,14 @@ define logrotate::conf (
     }
   }
 
-  if $su_user and !defined('$su_group') {
-    $_su_user  = $su_user
+  if $su_owner and !defined('$su_group') {
+    $_su_owner  = $su_owner
     $_su_group = 'root'
-  } elsif !defined('$su_user') and $su_group {
-    $_su_user  = 'root'
+  } elsif !defined('$su_owner') and $su_group {
+    $_su_owner  = 'root'
     $_su_group = $su_group
   } else {
-    $_su_user  = $su_user
+    $_su_owner  = $su_owner
     $_su_group = $su_group
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class logrotate::params {
       }
     }
     'Debian': {
-      $default_su_user = versioncmp($facts['operatingsystemmajrelease'], '14.00') ? {
+      $default_su_owner = versioncmp($facts['operatingsystemmajrelease'], '14.00') ? {
         1        => 'root',
         default  => undef,
       }
@@ -40,7 +40,7 @@ class logrotate::params {
         default   => undef
       }
       $conf_params = {
-        su_user  => $default_su_user,
+        su_owner  => $default_su_owner,
         su_group => $default_su_group,
       }
       $configdir     = '/etc'

--- a/spec/classes/defaults_spec.rb
+++ b/spec/classes/defaults_spec.rb
@@ -17,14 +17,14 @@ describe 'logrotate' do
       if facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease].to_i >= 14
         it {
           is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
-            'su_user' => 'root',
+            'su_owner' => 'root',
             'su_group' => 'syslog'
           )
         }
       else
         it {
           is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
-            'su_user' => nil,
+            'su_owner' => nil,
             'su_group' => nil
           )
         }

--- a/templates/etc/logrotate.conf.erb
+++ b/templates/etc/logrotate.conf.erb
@@ -43,8 +43,8 @@
 <% opts.each do |opt| -%>
 <%= opt %>
 <% end -%>
-<% if @_su_user != nil and @_su_group != nil -%>
-su <%= @_su_user %> <%= @_su_group %>
+<% if @_su_owner != nil and @_su_group != nil -%>
+su <%= @_su_owner %> <%= @_su_group %>
 <% end -%>
 <% if @postrotate != nil -%>
 postrotate


### PR DESCRIPTION
Unless there is a genuine reason for the parameters to diverge between ::conf and ::rule resources, then this should bring in line both of them.

I have purposefully left out the `su` parameter but can be added.