### PR TITLE
Allow logrotate version to be specified

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 #
 class logrotate (
-  Logrotate::Ensurable $ensure       = present,
+  String $ensure                     = present,
   Boolean $hieramerge                = false,
   Boolean $manage_cron_daily         = true,
   Boolean $purge_configdir           = false,

--- a/types/ensurable.pp
+++ b/types/ensurable.pp
@@ -1,1 +1,0 @@
-type Logrotate::Ensurable = Enum['present', 'absent', 'latest']


### PR DESCRIPTION
Also drop the Logrotate::Ensurable type - it's not used anywhere else.

Fixes #84 