### PR TITLE
Remove UserOrGroup type, use String

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -43,8 +43,8 @@ define logrotate::conf (
   Optional[Boolean] $shred                           = undef,
   Optional[Integer] $shredcycles                     = undef,
   Optional[Integer] $start                           = undef,
-  Optional[Logrotate::UserOrGroup] $su_user          = undef,
-  Optional[Logrotate::UserOrGroup] $su_group         = undef,
+  Optional[String] $su_user                          = undef,
+  Optional[String] $su_group                         = undef,
   Optional[String] $uncompresscmd                    = undef
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,8 +15,8 @@ class logrotate (
   String $logrotate_bin              = $logrotate::params::logrotate_bin,
   String $logrotate_conf             = $logrotate::params::logrotate_conf,
   String $rules_configdir            = $logrotate::params::rules_configdir,
-  Logrotate::UserOrGroup $root_user  = $logrotate::params::root_user,
-  Logrotate::UserOrGroup $root_group = $logrotate::params::root_group,
+  String $root_user                  = $logrotate::params::root_user,
+  String $root_group                 = $logrotate::params::root_group,
 ) inherits logrotate::params {
 
   contain ::logrotate::install

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -158,8 +158,8 @@ define logrotate::rule(
   Optional[Boolean] $shred                          = undef,
   Optional[Integer] $shredcycles                    = undef,
   Optional[Integer] $start                          = undef,
-  Optional[Logrotate::UserOrGroup] $su_owner        = undef,
-  Optional[Logrotate::UserOrGroup] $su_group        = undef,
+  Optional[String] $su_owner                        = undef,
+  Optional[String] $su_group                        = undef,
   Optional[String] $uncompresscmd                   = undef
 ) {
   case $ensure {

--- a/types/userorgroup.pp
+++ b/types/userorgroup.pp
@@ -1,1 +1,0 @@
-type Logrotate::UserOrGroup = Pattern[/^[a-z_][a-z0-9_\-]{0,30}$/]


### PR DESCRIPTION
The regex that matches a valid user or group is operating system and
distribution dependent. For instance, for older distributions the
contents of the useradd man page will often give a recommended regex,
rather than a required one.

Remove the UserOrGroup data type and use String instead to account for
horribly named users and groups.

Fixes #88 