### PR TITLE
Manage logrotate startup arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,19 @@ class { '::logrotate':
 }
 ```
 
+### Additional startup arguments
 
+With parameter `logrotate_args` you can specify additional startup arguments for logrotate. Configuration file is always added as the last argument for logrotate.
+
+This example tells logrotate to use an alternate state file and which command to use when mailing logs.
+
+```puppet
+class { '::logrotate':
+  ensure         => 'latest',
+  logrotate_args => ['-s /var/lib/logrotate/logrotate.status', '-m /usr/local/bin/mailer']
+  }
+}
+```
 ## Examples
 
 ```puppet

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -7,20 +7,20 @@ define logrotate::cron (
     default   => "/etc/cron.${name}/logrotate",
   }
 
-  $logrotate_path = $::logrotate::logrotate_bin
+  $logrotate_path = $logrotate::logrotate_bin
 
   if $name == 'hourly' {
-    $logrotate_conf = "${::logrotate::rules_configdir}/hourly"
+    $logrotate_conf = "${logrotate::rules_configdir}/hourly"
   } else {
-    $logrotate_conf = $::logrotate::logrotate_conf
+    $logrotate_conf = $logrotate::logrotate_conf
   }
 
   # If the logrotation config file is not yet in the arguments, add it
-  if ! ($logrotate_conf in $::logrotate::logrotate_args) {
-    $_logrotate_args = concat($::logrotate::logrotate_args,$logrotate_conf)
+  if ! ($logrotate_conf in $logrotate::logrotate_args) {
+    $_logrotate_args = concat($logrotate::logrotate_args,$logrotate_conf)
   }
   else {
-    $_logrotate_args = $::logrotate::logrotate_args
+    $_logrotate_args = $logrotate::logrotate_args
   }
 
   $logrotate_args = join($_logrotate_args, ' ')
@@ -30,10 +30,10 @@ define logrotate::cron (
   if $::osfamily == 'FreeBSD' {
     if $name == 'hourly' {
       $cron_hour   = '*'
-      $cron_minute = $::logrotate::cron_hourly_minute
+      $cron_minute = $logrotate::cron_hourly_minute
     } else {
-      $cron_hour   = $::logrotate::cron_daily_hour
-      $cron_minute = $::logrotate::cron_daily_minute
+      $cron_hour   = $logrotate::cron_daily_hour
+      $cron_minute = $logrotate::cron_daily_minute
     }
 
     cron { "logrotate_${name}":

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -10,10 +10,20 @@ define logrotate::cron (
   $logrotate_path = $::logrotate::logrotate_bin
 
   if $name == 'hourly' {
-    $logrotate_arg = "${::logrotate::rules_configdir}/hourly"
+    $logrotate_conf = "${::logrotate::rules_configdir}/hourly"
   } else {
-    $logrotate_arg = $::logrotate::logrotate_conf
+    $logrotate_conf = $::logrotate::logrotate_conf
   }
+
+  # If the logrotation config file is not yet in the arguments, add it
+  if ! ($logrotate_conf in $::logrotate::logrotate_args) {
+    $_logrotate_args = concat($::logrotate::logrotate_args,$logrotate_conf)
+  }
+  else {
+    $_logrotate_args = $::logrotate::logrotate_args
+  }
+
+  $logrotate_args = join($_logrotate_args, ' ')
 
   # FreeBSD does not have /etc/cron.daily, so we need to have Puppet maintain
   # a crontab entry

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@ class logrotate (
   Stdlib::Filemode $rules_configdir_mode = $logrotate::params::rules_configdir_mode,
   String $root_user                      = $logrotate::params::root_user,
   String $root_group                     = $logrotate::params::root_group,
+  Array[String] $logrotate_args          = []
 ) inherits logrotate::params {
 
   contain ::logrotate::install

--- a/spec/defines/cron_spec.rb
+++ b/spec/defines/cron_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'logrotate::cron' do
+  _, facts = on_supported_os.first
+  let(:facts) { facts }
+  let(:pre_condition) { 'class {"::logrotate": }' }
+
+  context 'Default params' do
+    let(:title) { 'test' }
+    let(:params) { { ensure: 'present' } }
+    let(:facts) { { osfamily: 'RedHat' } }
+
+    it {
+      is_expected.to contain_file('/etc/cron.test/logrotate').
+        with_ensure('present').
+        with_content(%r{(\/usr\/sbin\/logrotate \/etc\/logrotate.conf 2>&1)})
+    }
+  end
+
+  context 'Default params (FreeBSD)' do
+    let(:title) { 'test' }
+    let(:params) { { ensure: 'present' } }
+    let(:facts) { { osfamily: 'FreeBSD' } }
+
+    it {
+      is_expected.to contain_file('/usr/local/bin/logrotate.test.sh').
+        with_ensure('present').
+        with_content(%r{(\/usr\/local\/sbin\/logrotate \/usr\/local\/etc\/logrotate.conf 2>&1)})
+    }
+  end
+
+  context 'With additional arguments' do
+    let(:pre_condition) { 'class {"::logrotate": logrotate_args => ["-s /var/lib/logrotate/logrotate.status", "-m /usr/sbin/mailer"]}' }
+    let(:title) { 'test' }
+    let(:params) { { ensure: 'present' } }
+    let(:facts) { { osfamily: 'RedHat' } }
+
+    it {
+      is_expected.to contain_file('/etc/cron.test/logrotate').
+        with_content(%r{(\/usr\/sbin\/logrotate -s \/var\/lib\/logrotate\/logrotate.status -m \/usr\/sbin\/mailer \/etc\/logrotate.conf 2>&1)})
+    }
+  end
+end

--- a/spec/defines/cron_spec.rb
+++ b/spec/defines/cron_spec.rb
@@ -1,43 +1,83 @@
 require 'spec_helper'
 
 describe 'logrotate::cron' do
-  _, facts = on_supported_os.first
-  let(:facts) { facts }
-  let(:pre_condition) { 'class {"::logrotate": }' }
+  context 'supported operating systems' do
+    let(:pre_condition) { 'class { "::logrotate": }' }
 
-  context 'Default params' do
-    let(:title) { 'test' }
-    let(:params) { { ensure: 'present' } }
-    let(:facts) { { osfamily: 'RedHat' } }
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) do
+          facts
+        end
 
-    it {
-      is_expected.to contain_file('/etc/cron.test/logrotate').
-        with_ensure('present').
-        with_content(%r{(\/usr\/sbin\/logrotate \/etc\/logrotate.conf 2>&1)})
-    }
-  end
+        context 'With default params' do
+          let(:title) { 'test' }
+          let(:params) { { ensure: 'present' } }
 
-  context 'Default params (FreeBSD)' do
-    let(:title) { 'test' }
-    let(:params) { { ensure: 'present' } }
-    let(:facts) { { osfamily: 'FreeBSD' } }
+          if facts[:osfamily] != 'FreeBSD'
+            it {
+              is_expected.to contain_file('/etc/cron.test/logrotate').
+                with_ensure('present').
+                with_content(%r{(\/usr\/sbin\/logrotate \/etc\/logrotate.conf 2>&1)})
+            }
+          else
+            it {
+              is_expected.to contain_file('/usr/local/bin/logrotate.test.sh').
+                with_ensure('present').
+                with_content(%r{(\/usr\/local\/sbin\/logrotate \/usr\/local\/etc\/logrotate.conf 2>&1)})
+            }
+          end
+        end
 
-    it {
-      is_expected.to contain_file('/usr/local/bin/logrotate.test.sh').
-        with_ensure('present').
-        with_content(%r{(\/usr\/local\/sbin\/logrotate \/usr\/local\/etc\/logrotate.conf 2>&1)})
-    }
-  end
+        context 'With additional arguments' do
+          let(:pre_condition) { 'class {"::logrotate": logrotate_args => ["-s /var/lib/logrotate/logrotate.status", "-m /usr/sbin/mailer"]}' }
+          let(:title) { 'test' }
+          let(:params) { { ensure: 'present' } }
 
-  context 'With additional arguments' do
-    let(:pre_condition) { 'class {"::logrotate": logrotate_args => ["-s /var/lib/logrotate/logrotate.status", "-m /usr/sbin/mailer"]}' }
-    let(:title) { 'test' }
-    let(:params) { { ensure: 'present' } }
-    let(:facts) { { osfamily: 'RedHat' } }
+          if facts[:osfamily] != 'FreeBSD'
+            it {
+              is_expected.to contain_file('/etc/cron.test/logrotate').
+                with_ensure('present').
+                with_content(%r{(\/usr\/sbin\/logrotate -s \/var\/lib\/logrotate\/logrotate.status -m \/usr\/sbin\/mailer \/etc\/logrotate.conf 2>&1)})
+            }
+          else
+            it {
+              is_expected.to contain_file('/usr/local/bin/logrotate.test.sh').
+                with_ensure('present').
+                with_content(%r{(\/usr\/local\/sbin\/logrotate -s \/var\/lib\/logrotate\/logrotate.status -m \/usr\/sbin\/mailer \/usr\/local\/etc\/logrotate.conf 2>&1)})
+            }
+          end
+        end
+      end
+    end
 
-    it {
-      is_expected.to contain_file('/etc/cron.test/logrotate').
-        with_content(%r{(\/usr\/sbin\/logrotate -s \/var\/lib\/logrotate\/logrotate.status -m \/usr\/sbin\/mailer \/etc\/logrotate.conf 2>&1)})
-    }
+    # Test FreeBSD separately as it is only partially supported by the module and not in the list of supported os.
+    # When FreeBSD is added to the list of supported systems, these tests can be removed as they are already part of the test set above.
+    context 'on FreeBDS' do
+      let(:facts) { { osfamily: 'FreeBSD' } }
+
+      context 'With default params' do
+        let(:title) { 'test' }
+        let(:params) { { ensure: 'present' } }
+
+        it {
+          is_expected.to contain_file('/usr/local/bin/logrotate.test.sh').
+            with_ensure('present').
+            with_content(%r{(\/usr\/local\/sbin\/logrotate \/usr\/local\/etc\/logrotate.conf 2>&1)})
+        }
+      end
+
+      context 'With additional arguments' do
+        let(:pre_condition) { 'class {"::logrotate": logrotate_args => ["-s /var/lib/logrotate/logrotate.status", "-m /usr/sbin/mailer"]}' }
+        let(:title) { 'test' }
+        let(:params) { { ensure: 'present' } }
+
+        it {
+          is_expected.to contain_file('/usr/local/bin/logrotate.test.sh').
+            with_ensure('present').
+            with_content(%r{(\/usr\/local\/sbin\/logrotate -s \/var\/lib\/logrotate\/logrotate.status -m \/usr\/sbin\/mailer \/usr\/local\/etc\/logrotate.conf 2>&1)})
+        }
+      end
+    end
   end
 end

--- a/templates/etc/cron/logrotate.erb
+++ b/templates/etc/cron/logrotate.erb
@@ -2,7 +2,7 @@
 # THIS FILE IS AUTOMATICALLY DISTRIBUTED BY PUPPET.  ANY CHANGES WILL BE
 # OVERWRITTEN.
 
-OUTPUT=$(<%= @logrotate_path -%> <%= @logrotate_arg -%> 2>&1)
+OUTPUT=$(<%= @logrotate_path -%> <%= @logrotate_args -%> 2>&1)
 EXITVALUE=$?
 if [ $EXITVALUE != 0 ]; then
     /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"


### PR DESCRIPTION
This PR add a new parameter 'logrotate_args' for managing the startup parameters of logrotate. It is meant to supersede https://github.com/voxpupuli/puppet-logrotate/pull/67 which allows user to manage optional state file with similar technique.

The new parameter takes the arguments as an array. For example:
logrotate::logrotate_args: ['-s /var/lib/logrotate/logrotate.status', '-m /usr/local/bin/mailer'] 

Added new unit tests for the cron.pp

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
