### PR TITLE
Fix freebsd default rules

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,7 @@ class logrotate::params {
       $conf_params = {
         su_group => undef,
       }
+      $base_rules = {}
       $rule_default = {
         missingok    => true,
         rotate_every => 'monthly',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,16 +11,6 @@ class logrotate::params {
       $conf_params = {
         su_group => undef,
       }
-      $base_rules = {
-        'wtmp' => {
-          path        => '/var/log/wtmp',
-          create_mode => '0664',
-        },
-        'btmp' => {
-          path        => '/var/log/btmp',
-          create_mode => '0600',
-        },
-      }
       $rule_default = {
         missingok    => true,
         rotate_every => 'monthly',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
FreeBSD don't have any log file wtmp or btmp. So put logrotate rules by default on this files are useless.

The modification was tested on FreeBSD 11.1 with success.

#### This Pull Request (PR) fixes the following issues
There is no issue on it.