### PR TITLE
(docs) Update readme with warning note and bigger example of defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You may, optionally, define logrotate defaults using this defined type.
 Parameters are the same as those for logrotate::rule.
 Using this type will automatically include a private class that will install
 and configure logrotate for you.
+You must not also declare the `logrotate` class if using this defined type as you will encounter a Puppet error if you attempt to do so.
 
 ## logrotate::rule
 
@@ -148,8 +149,11 @@ This example will ensure that the logrotate package is latest and that the `date
 class { '::logrotate':
   ensure => 'latest',
   config => {
-    dateext  => true,
-    compress => true,
+    dateext      => true,
+    compress     => true,
+    rotate       => 10,
+    rotate_every => 'week',
+    ifempty      => true,
   }
 }
 ```


### PR DESCRIPTION
Declaring both `Logrotate::Conf['/etc/logrotate.conf]` and
`Class['logrotate']` will result in errors from Puppet as described
in #116 which is the result of not using the class correctly. Update
readme to add a not warning users not to do this and update the
example for `Class['logrotate']` to indicate that feature parity
with `Logrotate::Conf['/etc/logrotate.conf']` already exists.

Fixes #116

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
