### PR TITLE
Allow cron to always mail its output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ class { '::logrotate':
 ```
 ## Examples
 
+#### Cron output
+
+Default the cron output is discarded if there is no error output. To enable this output, when you (for example) enable the verbose startup argument, enable the $cron_always_output boolean on the logrotate class.
+
 ```puppet
 logrotate::conf { '/etc/logrotate.conf':
   rotate       => 10,

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -23,6 +23,8 @@ define logrotate::cron (
     $_logrotate_args = $logrotate::logrotate_args
   }
 
+  $cron_always_output = $logrotate::cron_always_output
+
   $logrotate_args = join($_logrotate_args, ' ')
 
   # FreeBSD does not have /etc/cron.daily, so we need to have Puppet maintain

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,8 @@ class logrotate (
   Stdlib::Filemode $rules_configdir_mode = $logrotate::params::rules_configdir_mode,
   String $root_user                      = $logrotate::params::root_user,
   String $root_group                     = $logrotate::params::root_group,
-  Array[String] $logrotate_args          = []
+  Array[String] $logrotate_args          = [],
+  Boolean $cron_always_output            = false,
 ) inherits logrotate::params {
 
   contain ::logrotate::install

--- a/spec/defines/cron_spec.rb
+++ b/spec/defines/cron_spec.rb
@@ -78,6 +78,18 @@ describe 'logrotate::cron' do
             with_content(%r{(\/usr\/local\/sbin\/logrotate -s \/var\/lib\/logrotate\/logrotate.status -m \/usr\/sbin\/mailer \/usr\/local\/etc\/logrotate.conf 2>&1)})
         }
       end
+
+      context 'With additional arguments' do
+        let(:pre_condition) { 'class {"::logrotate": cron_always_output => true}' }
+        let(:title) { 'test' }
+        let(:params) { { ensure: 'present' } }
+
+        it {
+          is_expected.to contain_file('/usr/local/bin/logrotate.test.sh').
+            with_ensure('present').
+            with_content(%r{(else\n    echo "${OUTPUT}"\nfi)})
+        }
+      end
     end
   end
 end

--- a/spec/defines/cron_spec.rb
+++ b/spec/defines/cron_spec.rb
@@ -87,7 +87,7 @@ describe 'logrotate::cron' do
         it {
           is_expected.to contain_file('/usr/local/bin/logrotate.test.sh').
             with_ensure('present').
-            with_content(%r{(else\n    echo "${OUTPUT}"\nfi)})
+            with_content(%r{(else\n    echo "\${OUTPUT}"\nfi)})
         }
       end
     end

--- a/templates/etc/cron/logrotate.erb
+++ b/templates/etc/cron/logrotate.erb
@@ -7,5 +7,9 @@ EXITVALUE=$?
 if [ $EXITVALUE != 0 ]; then
     /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
     echo "${OUTPUT}"
+<% if @cron_always_output -%>
+else
+    echo "${OUTPUT}"
+<% end -%>
 fi
 exit $EXITVALUE


### PR DESCRIPTION
I was used to the fact that redhat always mails its output. I enabled
the managed_cron bool, and added the --verbose startup argument (for
debugging) and all mail went away...

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
