### PR TITLE
Introduce new top level parameter manage_cron_hourly which defaults …

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,7 +20,7 @@ class logrotate::config{
     false => 'absent'
   }
 
-  logrotate::cron { 'daily': 
+  logrotate::cron { 'daily':
     ensure => $cron_ensure,
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,8 +15,13 @@ class logrotate::config{
     mode    => $logrotate::rules_configdir_mode,
   }
 
-  if $manage_cron_daily {
-    logrotate::cron { 'daily': }
+  $cron_ensure = $manage_cron_daily ? {
+    true  => 'present',
+    false => 'absent'
+  }
+
+  logrotate::cron { 'daily': 
+    ensure => $cron_ensure,
   }
 
   if is_hash($config) {

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -36,8 +36,8 @@ class logrotate::hourly (
   }
 
   if $manage_cron_hourly {
-    logrotate::cron { 'daily': 
-      ensure  => $icron_ensure,
+    logrotate::cron { 'hourly': 
+      ensure  => $cron_ensure,
       require => File["${logrotate::rules_configdir}/hourly"],
     }
   }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -16,7 +16,7 @@ class logrotate::hourly (
   Enum['present','absent'] $ensure = 'present'
 ) {
 
-  $manage_cron_hourly = $::logrotate::manage_cron_hourly
+  $manage_cron_hourly = $logrotate::manage_cron_hourly
 
   $dir_ensure = $ensure ? {
     'absent'  => $ensure,

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -23,6 +23,11 @@ class logrotate::hourly (
     'present' => 'directory'
   }
 
+  $cron_ensure = $manage_cron_hourly ? {
+    true  => $ensure,
+    false => 'absent'
+  }
+
   file { "${logrotate::rules_configdir}/hourly":
     ensure => $dir_ensure,
     owner  => 'root',
@@ -32,7 +37,7 @@ class logrotate::hourly (
 
   if $manage_cron_hourly {
     logrotate::cron { 'daily': 
-      ensure  => $ensure,
+      ensure  => $icron_ensure,
       require => File["${logrotate::rules_configdir}/hourly"],
     }
   }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -16,6 +16,8 @@ class logrotate::hourly (
   Enum['present','absent'] $ensure = 'present'
 ) {
 
+  $manage_cron_hourly = $::logrotate::manage_cron_hourly
+
   $dir_ensure = $ensure ? {
     'absent'  => $ensure,
     'present' => 'directory'
@@ -27,8 +29,11 @@ class logrotate::hourly (
     group  => 'root',
     mode   => $logrotate::rules_configdir_mode,
   }
-  -> logrotate::cron { 'hourly':
-      ensure => $ensure,
-    }
+
+  if $manage_cron_hourly {
+    logrotate::cron { 'daily': 
+      ensure  => $ensure,
+      require => File["${logrotate::rules_configdir}/hourly""],
+  }
 
 }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -33,7 +33,7 @@ class logrotate::hourly (
   if $manage_cron_hourly {
     logrotate::cron { 'daily': 
       ensure  => $ensure,
-      require => File["${logrotate::rules_configdir}/hourly""],
+      require => File["${logrotate::rules_configdir}/hourly"],
   }
 
 }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -36,7 +36,7 @@ class logrotate::hourly (
   }
 
   if $manage_cron_hourly {
-    logrotate::cron { 'hourly': 
+    logrotate::cron { 'hourly':
       ensure  => $cron_ensure,
       require => File["${logrotate::rules_configdir}/hourly"],
     }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -34,6 +34,7 @@ class logrotate::hourly (
     logrotate::cron { 'daily': 
       ensure  => $ensure,
       require => File["${logrotate::rules_configdir}/hourly"],
+    }
   }
 
 }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -34,12 +34,9 @@ class logrotate::hourly (
     group  => 'root',
     mode   => $logrotate::rules_configdir_mode,
   }
-
-  if $manage_cron_hourly {
-    logrotate::cron { 'hourly':
-      ensure  => $cron_ensure,
-      require => File["${logrotate::rules_configdir}/hourly"],
-    }
+  logrotate::cron { 'hourly':
+    ensure  => $cron_ensure,
+    require => File["${logrotate::rules_configdir}/hourly"],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class logrotate (
   String $ensure                         = present,
   Boolean $hieramerge                    = false,
   Boolean $manage_cron_daily             = true,
+  Boolean $manage_cron_hourly            = true,
   Boolean $create_base_rules             = true,
   Boolean $purge_configdir               = false,
   String $package                        = 'logrotate',


### PR DESCRIPTION
#### Pull Request (PR) description
Introduced new top level parameter manage_cron_hourly which defaults to true and controls whether the module manages the cron hourly job

#### This Pull Request (PR) fixes the following issues

Fixes #136
