### PR TITLE
Remove unused parameter: logrotate::cron_hourly_file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,6 @@ class logrotate (
   Integer[0,23] $cron_daily_hour         = $logrotate::params::cron_daily_hour,
   Integer[0,59] $cron_daily_minute       = $logrotate::params::cron_daily_minute,
   Integer[0,59] $cron_hourly_minute      = $logrotate::params::cron_hourly_minute,
-  String $cron_hourly_file               = $logrotate::params::cron_hourly_file,
   Stdlib::Filemode $cron_file_mode       = $logrotate::params::cron_file_mode,
   String $configdir                      = $logrotate::params::configdir,
   String $logrotate_bin                  = $logrotate::params::logrotate_bin,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -178,7 +178,6 @@ class logrotate::params {
   $cron_daily_hour    = 1
   $cron_daily_minute  = 0
   $cron_hourly_minute = 1
-  $cron_hourly_file   = '/etc/cron.hourly/logrotate'
   $config_file        = "${configdir}/logrotate.conf"
   $logrotate_conf     = "${configdir}/logrotate.conf"
   $manage_package     = true


### PR DESCRIPTION
The parameter logrotate::cron_hourly_file has already been removed in
favor of using logrotate::cron.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The parameter logrotate::cron_hourly_file has already been removed in
favor of using logrotate::cron.


#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
