### PR TITLE
Document possible use of Array for paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ and configure logrotate for you.
 
 ```
 namevar         - The String name of the rule.
-path            - The path String to the logfile(s) to be rotated.
+path            - The path(s) to the log file(s) to be rotated.  May be a 
+                  String or an Array of Strings.
 ensure          - The desired state of the logrotate rule as a String.  Valid
                   values are 'absent' and 'present' (default: 'present').
 compress        - A Boolean value specifying whether the rotated logs should
@@ -168,14 +169,24 @@ This example tells logrotate to use an alternate state file and which command to
 class { '::logrotate':
   ensure         => 'latest',
   logrotate_args => ['-s /var/lib/logrotate/logrotate.status', '-m /usr/local/bin/mailer']
+}
+```
+
+### Cron output
+
+By default, the cron output is discarded if there is no error output. To enable this output, when you (for example) enable the verbose startup argument, enable the `cron_always_output` boolean on the logrotate class:
+
+```puppet
+class { '::logrotate':
+  ensure              => 'latest',
+  cron_always_output  => true,
+  config              => {
+    ...
   }
 }
 ```
+
 ## Examples
-
-#### Cron output
-
-Default the cron output is discarded if there is no error output. To enable this output, when you (for example) enable the verbose startup argument, enable the $cron_always_output boolean on the logrotate class.
 
 ```puppet
 logrotate::conf { '/etc/logrotate.conf':
@@ -190,6 +201,13 @@ logrotate::rule { 'messages':
   rotate       => 5,
   rotate_every => 'week',
   postrotate   => '/usr/bin/killall -HUP syslogd',
+}
+
+logrotate::rule { 'servicelogs':
+  path         => ['/var/log/this-service.log', '/var/log/that-app.log'],
+  rotate       => 5,
+  rotate_every => 'day',
+  postrotate   => '/usr/bin/kill -HUP `cat /run/syslogd.pid`',
 }
 
 logrotate::rule { 'apache':


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This PR documents that it is possible to use an array of strings describing paths for the `path` rule configuration directive.  Includes an added example.

Also moved the note about cron output to the previous section as it seemed out of place, and fixed an extra closing brace in a prior example.

#### This Pull Request (PR) fixes the following issues

n/a.
