### PR TITLE
Use modern facts and $facts hash for osfamily

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -2,7 +2,7 @@
 define logrotate::cron (
   $ensure = 'present'
 ) {
-  $script_path = $facts['osfamily'] ? {
+  $script_path = $facts['os']['family'] ? {
     'FreeBSD' => "/usr/local/bin/logrotate.${name}.sh",
     default   => "/etc/cron.${name}/logrotate",
   }
@@ -29,7 +29,7 @@ define logrotate::cron (
 
   # FreeBSD does not have /etc/cron.daily, so we need to have Puppet maintain
   # a crontab entry
-  if $facts['osfamily'] == 'FreeBSD' {
+  if $facts['os']['family'] == 'FreeBSD' {
     if $name == 'hourly' {
       $cron_hour   = '*'
       $cron_minute = $logrotate::cron_hourly_minute

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -2,7 +2,7 @@
 define logrotate::cron (
   $ensure = 'present'
 ) {
-  $script_path = $::osfamily ? {
+  $script_path = $facts['osfamily'] ? {
     'FreeBSD' => "/usr/local/bin/logrotate.${name}.sh",
     default   => "/etc/cron.${name}/logrotate",
   }
@@ -29,7 +29,7 @@ define logrotate::cron (
 
   # FreeBSD does not have /etc/cron.daily, so we need to have Puppet maintain
   # a crontab entry
-  if $::osfamily == 'FreeBSD' {
+  if $facts['osfamily'] == 'FreeBSD' {
     if $name == 'hourly' {
       $cron_hour   = '*'
       $cron_minute = $logrotate::cron_hourly_minute

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 # Params class for logrotate module
 #
 class logrotate::params {
-  case $::osfamily {
+  case $facts['osfamily'] {
     'FreeBSD': {
       $configdir     = '/usr/local/etc'
       $root_group    = 'wheel'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 # Params class for logrotate module
 #
 class logrotate::params {
-  case $facts['osfamily'] {
+  case $facts['os']['family'] {
     'FreeBSD': {
       $configdir     = '/usr/local/etc'
       $root_group    = 'wheel'

--- a/spec/classes/defaults_spec.rb
+++ b/spec/classes/defaults_spec.rb
@@ -4,7 +4,7 @@ describe 'logrotate' do
   let(:pre_condition) { 'class { "::logrotate": }' }
 
   context 'no osfamily' do
-    let(:facts) { { osfamily: 'fake' } }
+    let(:facts) { { os: { family: 'fake' } } }
 
     it {
       is_expected.to contain_logrotate__conf('/etc/logrotate.conf')

--- a/spec/defines/cron_spec.rb
+++ b/spec/defines/cron_spec.rb
@@ -54,7 +54,7 @@ describe 'logrotate::cron' do
     # Test FreeBSD separately as it is only partially supported by the module and not in the list of supported os.
     # When FreeBSD is added to the list of supported systems, these tests can be removed as they are already part of the test set above.
     context 'on FreeBDS' do
-      let(:facts) { { osfamily: 'FreeBSD' } }
+      let(:facts) { { os: { family: 'FreeBSD' } } }
 
       context 'With default params' do
         let(:title) { 'test' }

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -706,7 +706,7 @@ describe 'logrotate::rule' do
     end
     let(:facts) do
       {
-        osfamily: 'RedHat',
+        os: { family: 'RedHat' },
         operatingsystemmajrelease: 7
       }
     end


### PR DESCRIPTION
#### Pull Request (PR) description
Replacing `$::osfamily` as running tests against Puppet 6 suggest it no longer exists, and instead only exists in `$facts`
