### PR TITLE
Remove deprecated and unused is_hash function

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@ class logrotate::config{
   assert_private()
 
   $manage_cron_daily = $::logrotate::manage_cron_daily
+  $logrotate_conf    = $::logrotate::logrotate_conf
   $config            = $::logrotate::config
 
   file{ $::logrotate::rules_configdir:
@@ -24,9 +25,10 @@ class logrotate::config{
     ensure => $cron_ensure,
   }
 
-  if is_hash($config) {
-    $custom_config = {"${logrotate::logrotate_conf}" => $config}
-    create_resources('logrotate::conf', $custom_config)
+  if $config {
+    logrotate::conf { $logrotate_conf:
+      * => $config,
+    }
   }
 
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -71,6 +71,16 @@ describe 'logrotate' do
             is_expected.not_to contain_logrotate__rule('wtmp')
           end
         end
+
+        context 'with config => { prerotate => "/usr/bin/test", rotate_every => "daily" }' do
+          let(:params) { { config: { prerotate: '/usr/bin/test', rotate_every: 'daily' } } }
+
+          it {
+            is_expected.to contain_logrotate__conf('/etc/logrotate.conf').
+              with_prerotate('/usr/bin/test').
+              with_rotate_every('daily')
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR removes the usage of the deprecated `is_hash` function and moves the creation of `Logrotate::Conf[$logrotate_conf]` to a native Puppet 4 way.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
