### PR TITLE
Allow puppetlabs-stdlib 6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.22.0 < 6.0.0"
+      "version_requirement": ">= 4.22.0 < 7.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
#### Pull Request (PR) description
Update the metadata.json file to support using puppetlabs-stdlib v6

Full changelog: https://github.com/puppetlabs/puppetlabs-stdlib/compare/5.2.0...v6.0.0
Short changelog: https://forge.puppet.com/puppetlabs/stdlib/changelog#supported-release-600

The only thing that seems concerning for this module might be https://github.com/puppetlabs/puppetlabs-stdlib/commit/9e8ce942961f9d615203efa4da2de570cf9f420e but defer to you fine folks on that. 

#### This Pull Request (PR) fixes the following issues
n/a
