### PR TITLE
Use /usr/sbin/logrotate as $logrotate_bin default value with Gentoo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,7 +71,7 @@ class logrotate::params {
       }
       $configdir     = '/etc'
       $root_group    = 'root'
-      $logrotate_bin = '/usr/sbin/logrotate'
+      $logrotate_bin = '/usr/bin/logrotate'
       $base_rules = {
         'wtmp' => {
           path        => '/var/log/wtmp',


### PR DESCRIPTION
#### Pull Request (PR) description
Gentoo changed paths and us now using `/usr/bin/logrotate` instead of `/usr/sbin/logrotate`

See https://gitweb.gentoo.org/repo/gentoo.git/tree/app-admin/logrotate/logrotate-3.14.0.ebuild#n85

This PR fixes the path to the logrotate binary when using Gentoo

#### This Pull Request (PR) fixes the following issues

Fixes #167
