### PR TITLE
Drop EOL EL6 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,7 +5,6 @@
     - set: ubuntu1804-64
     - set: ubuntu1604-64
     - set: centos7-64
-    - set: centos6-64
     - set: debian9-64
     - set: debian8-64
 spec/spec_helper_acceptance.rb:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,14 +50,6 @@ jobs:
       services: docker
     - rvm: 2.5.3
       bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
       env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=debian9-64 CHECK=beaker
       services: docker
     - rvm: 2.5.3

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
@@ -46,21 +45,18 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
Now that CentOS 6 is EOL and is being removed from the mirror network we have no way to test this anymore.