### PR TITLE
Fix FreeBSD group issue

### DIFF
--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -26,8 +26,8 @@ class logrotate::hourly (
 
   file { "${logrotate::rules_configdir}/hourly":
     ensure => $dir_ensure,
-    owner  => 'root',
-    group  => 'root',
+    owner  => $logrotate::root_user,
+    group  => $logrotate::root_group,
     mode   => $logrotate::rules_configdir_mode,
   }
 


### PR DESCRIPTION
in this file, the user and group are defined as root. in other files you use params which are defined with values in the param file as you check the OS before.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
the user and group name was hardcoded defined as root which produce exception on freebsd (no group with root are available.

#### This Pull Request (PR) fixes the following issues

I removed the hardcoded names and changed it into you predefined vars from params.pp which will filled with the right values for OS.