### PR TITLE
Update defaults to match RHEL8/9

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,10 +104,12 @@ class logrotate::params {
       $configdir     = '/etc'
       $root_group    = 'root'
       $logrotate_bin = '/usr/sbin/logrotate'
+
+      $wtmp_missingok = versioncmp($facts['os']['release']['major'],'8') >= 0
       $base_rules = {
         'wtmp' => {
           path        => '/var/log/wtmp',
-          missingok   => false,
+          missingok   => $wtmp_missingok,
           create_mode => '0664',
           minsize     => '1M',
         },

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,9 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {
@@ -50,7 +52,9 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/classes/defaults_spec.rb
+++ b/spec/classes/defaults_spec.rb
@@ -67,7 +67,7 @@ describe 'logrotate' do
         is_expected.to contain_logrotate__rule('wtmp').with(
           'path' => '/var/log/wtmp',
           'create_mode' => '0664',
-          'missingok' => false,
+          'missingok' => facts[:operatingsystemmajrelease].to_i >= 8,
           'minsize' => '1M',
           'create' => true,
           'create_owner' => 'root',

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -720,7 +720,7 @@ describe 'logrotate::rule' do
     end
     let(:facts) do
       {
-        os: { family: 'RedHat' },
+        os: { family: 'RedHat', release: { major: '7' } },
         operatingsystemmajrelease: 7
       }
     end


### PR DESCRIPTION
#### Pull Request (PR) description
RHEL8 and later use a slightly different default for `wtmp`

#### This Pull Request (PR) fixes the following issues
N/A