### PR TITLE
Support hourly logrotate directory on EL9 again.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,3 +2,4 @@ fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     cron: "https://github.com/puppetlabs/puppetlabs-cron_core.git"
+    systemd: "https://github.com/voxpupuli/puppet-systemd.git"

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -19,13 +19,8 @@ class logrotate::hourly (
 ) {
   assert_private()
 
-  $dir_ensure = $logrotate::ensure_cron_hourly ? {
-    'absent'  => $logrotate::ensure_cron_hourly,
-    'present' => 'directory'
-  }
-
   file { "${logrotate::rules_configdir}/hourly":
-    ensure => $dir_ensure,
+    ensure => 'directory',
     owner  => $logrotate::root_user,
     group  => $logrotate::root_group,
     mode   => $logrotate::rules_configdir_mode,
@@ -36,6 +31,57 @@ class logrotate::hourly (
     logrotate::cron { 'hourly':
       ensure  => $logrotate::ensure_cron_hourly,
       require => File["${logrotate::rules_configdir}/hourly"],
+    }
+  }
+
+  # Make copies of the rpm provided unit and timers
+  if $logrotate::manage_systemd_timer {
+    systemd::manage_dropin { 'hourly-service.conf':
+      ensure        => $logrotate::ensure_systemd_timer,
+      unit          => 'logrotate-hourly.service',
+      unit_entry    => {
+        'Description' => [
+          '',
+          'Extra service to run hourly logrotates only',
+        ],
+      },
+      service_entry => {
+        'ExecStart'   => ['', "/usr/sbin/logrotate ${logrotate::rules_configdir}/hourly"],
+      },
+      before        => Systemd::Unit_file['logrotate-hourly.service'],
+    }
+
+    systemd::unit_file { 'logrotate-hourly.service':
+      ensure => $logrotate::ensure_systemd_timer,
+      source => 'file:///lib/systemd/system/logrotate.service',
+      before => Systemd::Unit_file['logrotate-hourly.timer'],
+    }
+
+    systemd::manage_dropin { 'hourly-timer.conf':
+      ensure      => $logrotate::ensure_systemd_timer,
+      unit        => 'logrotate-hourly.timer',
+      unit_entry  => {
+        'Description' => [
+          '',
+          'Extra timer to run hourly logrotates only',
+        ],
+      },
+      timer_entry => {
+        'OnCalendar'   => ['', 'hourly'],
+      },
+      before      => Systemd::Unit_file['logrotate-hourly.timer'],
+    }
+
+    $_timer = $logrotate::ensure_systemd_timer ? {
+      'present' => true,
+      default  => false,
+    }
+
+    systemd::unit_file { 'logrotate-hourly.timer':
+      ensure => $logrotate::ensure_systemd_timer,
+      source => 'file:///lib/systemd/system/logrotate.timer',
+      active => $_timer,
+      enable => $_timer,
     }
   }
 }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -36,6 +36,8 @@ class logrotate::hourly (
 
   # Make copies of the rpm provided unit and timers
   if $logrotate::manage_systemd_timer {
+    $_lockfile = '/run/lock/logrotate.service'
+    $_timeout  = 21600
     systemd::manage_dropin { 'hourly-service.conf':
       ensure        => $logrotate::ensure_systemd_timer,
       unit          => 'logrotate-hourly.service',
@@ -46,9 +48,18 @@ class logrotate::hourly (
         ],
       },
       service_entry => {
-        'ExecStart'   => ['', "/usr/sbin/logrotate ${logrotate::rules_configdir}/hourly"],
+        'ExecStart' => ['', "/usr/bin/flock --wait ${_timeout} ${_lockfile} /usr/sbin/logrotate ${logrotate::rules_configdir}/hourly"],
       },
       before        => Systemd::Unit_file['logrotate-hourly.service'],
+    }
+
+    # Once logrotate >= 3.21.1 replace flock with the `--wait-for-state-lock` option.
+    systemd::manage_dropin { 'logrotate-flock.conf':
+      ensure        => $logrotate::ensure_systemd_timer,
+      unit          => 'logrotate.service',
+      service_entry => {
+        'ExecStart'   => ['', "/usr/bin/flock --wait ${_timeout} ${_lockfile} /usr/sbin/logrotate /etc/logrotate.conf"],
+      },
     }
 
     systemd::unit_file { 'logrotate-hourly.service':

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.22.0 < 10.0.0"
+    },
+    {
+      "name": "puppet/systemd",
+      "version_requirement": ">= 6.3.0 < 7.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -74,7 +74,24 @@ describe 'logrotate' do
 
                 is_expected.to contain_systemd__manage_dropin('hourly-service.conf').with(
                   'ensure' => 'present',
-                  'unit'   => 'logrotate-hourly.service'
+                  'unit' => 'logrotate-hourly.service',
+                  'service_entry' => {
+                    'ExecStart' => [
+                      '',
+                      '/usr/bin/flock --wait 21600 /run/lock/logrotate.service /usr/sbin/logrotate /etc/logrotate.d/hourly'
+                    ]
+                  }
+                )
+
+                is_expected.to contain_systemd__manage_dropin('logrotate-flock.conf').with(
+                  'ensure' => 'present',
+                  'unit' => 'logrotate.service',
+                  'service_entry' => {
+                    'ExecStart' => [
+                      '',
+                      '/usr/bin/flock --wait 21600 /run/lock/logrotate.service /usr/sbin/logrotate /etc/logrotate.conf'
+                    ]
+                  }
                 )
               end
             else
@@ -108,6 +125,7 @@ describe 'logrotate' do
                 is_expected.not_to contain_systemd__unit_file('logrotate-hourly.service')
                 is_expected.not_to contain_systemd__unit_file('logrotate-hourly.timer')
                 is_expected.not_to contain_systemd__unit_file('logrotate-hourly.service')
+                is_expected.not_to contain_systemd__manage_dropin('logrotate-flock.conf')
               end
             end
           end


### PR DESCRIPTION
#### Pull Request (PR) description

When EL9 switched to using systemd (quite correctly ) in #216 support for a special directory for hourly logrotations was removed - that change was backwards incompatible.

Add that functionality back with a new unit and timer
* `logrotate-hourly.service`
* `logrotate-hourly.timer`

While this could be achieved by reducing the period of existing timer to hourly I presume the motivation for this was to avoid processing all logrotate directives every hour which does make some sense.

Following this patch:

```
# systemctl list-timers | grep logro
Mon 2024-02-19 14:00:00 CET 46min left  -                           -            logrotate-hourly.timer       logrotate-hourly.service
Tue 2024-02-20 00:00:00 CET 10h left    Mon 2024-02-19 09:53:53 CET 3h 19min ago logrotate.timer              logrotate.service
```

and

```
# systemctl show logrotate-hourly.service -p ExecStart
ExecStart={ path=/usr/sbin/logrotate ; argv[]=/usr/sbin/logrotate /etc/logrotate.d/hourly ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }
```

