### PR TITLE
Manage cron subdirectories, if needed

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -46,6 +46,24 @@ define logrotate::cron (
     }
   }
 
+  if $logrotate::manage_cron_subdirectories {
+    case $facts['os']['family'] {
+      'FreeBSD': {}
+      default: {
+        $cron_dir = "/etc/cron.${name}"
+        ensure_resources('file', { $cron_dir => {
+              ensure => directory,
+              owner => $logrotate::root_user,
+              group => $logrotate::root_group,
+        } })
+
+        File <<| name == $script_path |>> {
+          require => File[$cron_dir]
+        }
+      }
+    }
+  }
+
   file { $script_path:
     ensure  => $ensure,
     owner   => $logrotate::root_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class logrotate (
   String $root_group                         = $logrotate::params::root_group,
   Array[String[1]] $logrotate_args           = [],
   Boolean $cron_always_output                = false,
+  Boolean $manage_cron_subdirectories        = true,
 ) inherits logrotate::params {
   contain logrotate::install
   contain logrotate::config

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -203,6 +203,28 @@ describe 'logrotate' do
             it { is_expected.to contain_file('/etc/cron.hourly/logrotate').with_ensure('absent') }
           end
         end
+
+        context 'with logrotate rule' do
+          let(:params) {{
+            manage_cron_hourly: true,
+            rules: {
+              nginx: {
+                path: ['/var/log/nginx/*.log'],
+                rotate_every: 'hour',
+              }
+            }
+          }}
+
+          case os_facts['os']['name']
+          when 'FreeBSD'
+            it { is_expected.to contain_file('/usr/local/etc/logrotate.d/hourly').with_ensure('directory') }
+          else
+            it { is_expected.to contain_file('/etc/logrotate.d/hourly').with_ensure('directory') }
+            it { is_expected.to contain_file('/etc/logrotate.d/hourly/nginx').with_ensure('present').with_content(%r{/var/log/nginx/\*.log\s\{\n\s+hourly\n\}}) }
+            it { is_expected.to contain_file('/etc/cron.hourly').with_ensure('directory') }
+            it { is_expected.to contain_logrotate__rule('nginx') }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION

#### Pull Request (PR) description

Cron sub-directories like `/etc/cron.hourly` might not be present on all distributions, then creating e.g. the hourly rule would be failing.

This PR ensures that the parent directory exists.
