### PR TITLE
Add Ubuntu 20.04, 22.04, 24.04 support

### DIFF
--- a/data/Ubuntu.yaml
+++ b/data/Ubuntu.yaml
@@ -1,0 +1,5 @@
+---
+logrotate::ensure_cron_daily: absent
+logrotate::ensure_cron_hourly: absent
+logrotate::manage_systemd_timer: true
+logrotate::ensure_systemd_timer: present

--- a/data/Ubuntu/18.04.yaml
+++ b/data/Ubuntu/18.04.yaml
@@ -1,0 +1,5 @@
+---
+logrotate::ensure_cron_daily: present
+logrotate::ensure_cron_hourly: present
+logrotate::manage_systemd_timer: false
+logrotate::ensure_systemd_timer: absent

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,11 +6,14 @@ defaults:
   data_hash: yaml_data
 
 hierarchy:
-  - name: 'Distribution Name'
-    path: "%{facts.os.name}.yaml"
-  - name: 'Operating System Family - Major version'
-    path: "%{facts.os.family}/%{facts.os.release.major}.yaml"
+  - name: 'Operating System Family - Major Release'
+    paths:
+     # Used to distinguish between Debian and Ubuntu
+      - "%{facts.os.name}/%{facts.os.release.major}.yaml"
+      - "%{facts.os.family}/%{facts.os.release.major}.yaml"
   - name: 'Operating System Family'
-    path: "%{facts.os.family}.yaml"
+    paths:
+      - "%{facts.os.name}.yaml"
+      - "%{facts.os.family}.yaml"
   - name: 'defaults'
     path: 'defaults.yaml'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,10 +30,17 @@ class logrotate::params {
         'Ubuntu' => 'root',
         default  => undef,
       }
+
+      $ubuntu_default_su_group = $facts['os']['release']['full'] ? {
+        '18.04' => 'syslog',
+        default => 'adm',
+      }
+
       $default_su_group = $facts['os']['name'] ? {
-        'Ubuntu'  => 'syslog',
+        'Ubuntu'  => $ubuntu_default_su_group,
         default   => undef
       }
+
       $conf_params = {
         su       => $default_su,
         su_user  => $default_su_user,

--- a/metadata.json
+++ b/metadata.json
@@ -80,7 +80,9 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "18.04",
+        "22.04",
+        "24.04"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -81,6 +81,7 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
+        "20.04",
         "22.04",
         "24.04"
       ]

--- a/spec/classes/defaults_spec.rb
+++ b/spec/classes/defaults_spec.rb
@@ -18,19 +18,8 @@ describe 'logrotate' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_logrotate__conf('/etc/logrotate.conf') }
 
-      if os_facts['os']['name'] == 'Ubuntu'
-        it {
-          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
-            'su_user' => 'root',
-            'su_group' => 'syslog'
-          )
-        }
-      else
-        it {
-          is_expected.to contain_logrotate__conf('/etc/logrotate.conf')
-        }
-      end
       it {
         is_expected.to contain_logrotate__rule('wtmp').with(
           'rotate_every' => 'monthly',
@@ -54,6 +43,27 @@ describe 'logrotate' do
           'missingok' => true
         )
       }
+    end
+
+    context os, if: os_facts['os']['name'] == 'Ubuntu' do
+      let(:facts) { os_facts }
+
+      if os_facts['os']['release']['full'] == '18.04'
+        it {
+          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
+            'su_user' => 'root',
+            'su_group' => 'syslog'
+          )
+        }
+      end
+      if os_facts['os']['release']['full'] == '22.04'
+        it {
+          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
+            'su_user' => 'root',
+            'su_group' => 'adm'
+          )
+        }
+      end
     end
 
     context os, if: os_facts['os']['family'] == 'RedHat' do

--- a/spec/classes/defaults_spec.rb
+++ b/spec/classes/defaults_spec.rb
@@ -48,15 +48,14 @@ describe 'logrotate' do
     context os, if: os_facts['os']['name'] == 'Ubuntu' do
       let(:facts) { os_facts }
 
-      if os_facts['os']['release']['full'] == '18.04'
+      if os_facts['os']['release']['full'].to_i <= 18
         it {
           is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
             'su_user' => 'root',
             'su_group' => 'syslog'
           )
         }
-      end
-      if os_facts['os']['release']['full'] == '22.04'
+      else
         it {
           is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
             'su_user' => 'root',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -52,7 +52,8 @@ describe 'logrotate' do
               is_expected.to contain_class('logrotate::defaults')
             end
 
-            if os_facts['os']['family'] == 'RedHat' && os_facts['os']['release']['major'].to_i >= 9
+            if (os_facts['os']['family'] == 'RedHat' && os_facts['os']['release']['major'].to_i >= 9) ||
+               (os_facts['os']['name']   == 'Ubuntu' && os_facts['os']['release']['major'].to_i >= 20)
               it do
                 is_expected.to contain_service('logrotate.timer').with(
                   'ensure' => 'running',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add Ubuntu 20.04, 22.04, 24.04 support:

- Update default value "su_group" to be in line with Ubuntu 20.04+
- default to systemd-timer instead of cron on Ubuntu 20.04+


#### This Pull Request (PR) fixes the following issues

Fixes:
 - #218
 - #191
 - #154

Supersedes:
- https://github.com/voxpupuli/puppet-logrotate/pull/231
