### PR TITLE
Allow disabling logrotate-hourly when using systemd

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -45,6 +45,7 @@ The following parameters are available in the `logrotate` class:
 * [`ensure_cron_hourly`](#-logrotate--ensure_cron_hourly)
 * [`manage_systemd_timer`](#-logrotate--manage_systemd_timer)
 * [`ensure_systemd_timer`](#-logrotate--ensure_systemd_timer)
+* [`ensure_systemd_timer_hourly`](#-logrotate--ensure_systemd_timer_hourly)
 * [`create_base_rules`](#-logrotate--create_base_rules)
 * [`purge_configdir`](#-logrotate--purge_configdir)
 * [`package`](#-logrotate--package)
@@ -123,6 +124,14 @@ Data type: `Boolean`
 Default value: `false`
 
 ##### <a name="-logrotate--ensure_systemd_timer"></a>`ensure_systemd_timer`
+
+Data type: `Enum[present,absent]`
+
+
+
+Default value: `'absent'`
+
+##### <a name="-logrotate--ensure_systemd_timer_hourly"></a>`ensure_systemd_timer_hourly`
 
 Data type: `Enum[present,absent]`
 

--- a/data/RedHat/9.yaml
+++ b/data/RedHat/9.yaml
@@ -3,3 +3,4 @@ logrotate::ensure_cron_daily: absent
 logrotate::ensure_cron_hourly: absent
 logrotate::manage_systemd_timer: true
 logrotate::ensure_systemd_timer: present
+logrotate::ensure_systemd_timer_hourly: present

--- a/data/Ubuntu.yaml
+++ b/data/Ubuntu.yaml
@@ -3,3 +3,4 @@ logrotate::ensure_cron_daily: absent
 logrotate::ensure_cron_hourly: absent
 logrotate::manage_systemd_timer: true
 logrotate::ensure_systemd_timer: present
+logrotate::ensure_systemd_timer_hourly: present

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -39,7 +39,7 @@ class logrotate::hourly (
     $_lockfile = '/run/lock/logrotate.service'
     $_timeout  = 21600
     systemd::manage_dropin { 'hourly-service.conf':
-      ensure        => $logrotate::ensure_systemd_timer,
+      ensure        => $logrotate::ensure_systemd_timer_hourly,
       unit          => 'logrotate-hourly.service',
       unit_entry    => {
         'Description' => [
@@ -55,7 +55,7 @@ class logrotate::hourly (
 
     # Once logrotate >= 3.21.1 replace flock with the `--wait-for-state-lock` option.
     systemd::manage_dropin { 'logrotate-flock.conf':
-      ensure        => $logrotate::ensure_systemd_timer,
+      ensure        => $logrotate::ensure_systemd_timer_hourly,
       unit          => 'logrotate.service',
       service_entry => {
         'ExecStart'   => ['', "/usr/bin/flock --wait ${_timeout} ${_lockfile} /usr/sbin/logrotate /etc/logrotate.conf"],
@@ -63,13 +63,13 @@ class logrotate::hourly (
     }
 
     systemd::unit_file { 'logrotate-hourly.service':
-      ensure => $logrotate::ensure_systemd_timer,
+      ensure => $logrotate::ensure_systemd_timer_hourly,
       source => 'file:///lib/systemd/system/logrotate.service',
       before => Systemd::Unit_file['logrotate-hourly.timer'],
     }
 
     systemd::manage_dropin { 'hourly-timer.conf':
-      ensure      => $logrotate::ensure_systemd_timer,
+      ensure      => $logrotate::ensure_systemd_timer_hourly,
       unit        => 'logrotate-hourly.timer',
       unit_entry  => {
         'Description' => [
@@ -83,13 +83,13 @@ class logrotate::hourly (
       before      => Systemd::Unit_file['logrotate-hourly.timer'],
     }
 
-    $_timer = $logrotate::ensure_systemd_timer ? {
+    $_timer = $logrotate::ensure_systemd_timer_hourly ? {
       'present' => true,
       default  => false,
     }
 
     systemd::unit_file { 'logrotate-hourly.timer':
-      ensure => $logrotate::ensure_systemd_timer,
+      ensure => $logrotate::ensure_systemd_timer_hourly,
       source => 'file:///lib/systemd/system/logrotate.timer',
       active => $_timer,
       enable => $_timer,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class logrotate (
   Enum[present,absent] $ensure_cron_hourly   = 'present',
   Boolean $manage_systemd_timer              = false,
   Enum[present,absent] $ensure_systemd_timer = 'absent',
+  Enum[present,absent] $ensure_systemd_timer_hourly = 'absent',
   Boolean $create_base_rules                 = true,
   Boolean $purge_configdir                   = false,
   String $package                            = 'logrotate',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -204,6 +204,31 @@ describe 'logrotate' do
             it { is_expected.to contain_file('/etc/cron.hourly/logrotate').with_ensure('absent') }
           end
         end
+
+        context 'with ensure_systemd_timer_hourly => absent' do
+          let(:params) do
+            {
+              manage_systemd_timer: true,
+              ensure_systemd_timer: 'present',
+              ensure_systemd_timer_hourly: 'absent',
+            }
+          end
+
+          case os_facts['os']['name']
+          when 'FreeBSD'
+            it { is_expected.to contain_file('/usr/local/etc/logrotate.d/hourly').with_ensure('directory') }
+          else
+            it { is_expected.to contain_file('/etc/logrotate.d/hourly').with_ensure('directory') }
+
+            it do
+              is_expected.to contain_systemd__manage_dropin('hourly-service.conf').with_ensure('absent')
+              is_expected.to contain_systemd__manage_dropin('logrotate-flock.conf').with_ensure('absent')
+              is_expected.to contain_systemd__unit_file('logrotate-hourly.service').with_ensure('absent')
+              is_expected.to contain_systemd__manage_dropin('hourly-timer.conf').with_ensure('absent')
+              is_expected.to contain_systemd__unit_file('logrotate-hourly.timer').with_ensure('absent')
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

Similar to the option to disable hourly logrotation when using Cron (`logrotate::ensure_cron_hourly => absent`) this change allows to optionally disable hourly logrotation when using systemd. Previously this was not possible; when the systemd timer/service for logrotate is managed then the hourly logrotation timer/service is also present and enabled.

With this change we introduce the class parameter
`logrotate::ensure_systemd_timer_hourly` which defaults to "present", but can be set to "absent" so that any hourly logrotation timer, service and drop-in are removed.

This can be useful in cases where the usage of "flock" conflicts with "postrotate" commands that inadvertently take ownership of the lock file and keep it open indefinitely; this results in logrotate blocking completely and eventually failing when the lock expires after six hours.

#### This Pull Request (PR) fixes the following issues

Fixes #248