### PR TITLE
Clarify why flock is used when hourly rotation is enabled

### DIFF
--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -53,6 +53,7 @@ class logrotate::hourly (
       before        => Systemd::Unit_file['logrotate-hourly.service'],
     }
 
+    # Ensure our separate systemd units do not run concurrently.
     # Once logrotate >= 3.21.1 replace flock with the `--wait-for-state-lock` option.
     systemd::manage_dropin { 'logrotate-flock.conf':
       ensure        => $logrotate::ensure_systemd_timer_hourly,


### PR DESCRIPTION
Short clarification of the conversation that happened in the original PR: https://github.com/voxpupuli/puppet-logrotate/pull/221#discussion_r1494870223
