### PR TITLE
Have Ubuntu 20 and 22 use cron instead of systemd timer

### DIFF
--- a/data/Ubuntu/20.yaml
+++ b/data/Ubuntu/20.yaml
@@ -1,0 +1,8 @@
+---
+logrotate::manage_cron_daily: true
+logrotate::manage_cron_hourly: true
+logrotate::ensure_cron_daily: present
+logrotate::ensure_cron_hourly: present
+logrotate::manage_systemd_timer: false
+logrotate::ensure_systemd_timer: absent
+logrotate::ensure_systemd_timer_hourly: absent

--- a/data/Ubuntu/22.yaml
+++ b/data/Ubuntu/22.yaml
@@ -1,0 +1,8 @@
+---
+logrotate::manage_cron_daily: true
+logrotate::manage_cron_hourly: true
+logrotate::ensure_cron_daily: present
+logrotate::ensure_cron_hourly: present
+logrotate::manage_systemd_timer: false
+logrotate::ensure_systemd_timer: absent
+logrotate::ensure_systemd_timer_hourly: absent


### PR DESCRIPTION
#### Pull Request (PR) description

Have Ubuntu 20 and 22 use cron since that's what they default to.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-logrotate/issues/264
