### PR TITLE
Remove unused `hieramerge` param

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -38,7 +38,6 @@ The logrotate class.
 The following parameters are available in the `logrotate` class:
 
 * [`ensure`](#-logrotate--ensure)
-* [`hieramerge`](#-logrotate--hieramerge)
 * [`manage_cron_daily`](#-logrotate--manage_cron_daily)
 * [`manage_cron_hourly`](#-logrotate--manage_cron_hourly)
 * [`ensure_cron_daily`](#-logrotate--ensure_cron_daily)
@@ -74,14 +73,6 @@ Data type: `String`
 
 
 Default value: `present`
-
-##### <a name="-logrotate--hieramerge"></a>`hieramerge`
-
-Data type: `Boolean`
-
-
-
-Default value: `false`
 
 ##### <a name="-logrotate--manage_cron_daily"></a>`manage_cron_daily`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,6 @@
 #
 class logrotate (
   String $ensure                             = present,
-  Boolean $hieramerge                        = false,
   Boolean $manage_cron_daily                 = true,
   Boolean $manage_cron_hourly                = true,
   Enum[present,absent] $ensure_cron_daily    = 'present',


### PR DESCRIPTION
#### Pull Request (PR) description

Remove unused `hieramerge` param.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-logrotate/issues/267
