### PR TITLE
Add support for `createolddir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ missingok       - A Boolean specifying whether logrotate should ignore missing
                   log files or issue an error (optional).
 olddir          - A String path to a directory that rotated logs should be
                   moved to (optional).
+createolddir    - A Boolean specifying whether logrotate should create the
+                  olddir directory if it does not exist (optional).
+createolddir_mode - An octal mode String logrotate should apply to the
+                  olddir directory if createolddir => true (optional).
+createolddir_owner - A username String that logrotate should set the owner
+                  of the olddir directory to if createolddir => true (optional).
+createolddir_group - A String group name that logrotate should apply to the
+                  olddir directory if createolddir => true (optional).
 postrotate      - A command String that should be executed by /bin/sh after
                   the log file is rotated (optional).
 prerotate       - A command String that should be executed by /bin/sh before

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -416,6 +416,10 @@ The following parameters are available in the `logrotate::conf` defined type:
 * [`create_mode`](#-logrotate--conf--create_mode)
 * [`create_owner`](#-logrotate--conf--create_owner)
 * [`create_group`](#-logrotate--conf--create_group)
+* [`createolddir`](#-logrotate--conf--createolddir)
+* [`createolddir_mode`](#-logrotate--conf--createolddir_mode)
+* [`createolddir_owner`](#-logrotate--conf--createolddir_owner)
+* [`createolddir_group`](#-logrotate--conf--createolddir_group)
 * [`dateext`](#-logrotate--conf--dateext)
 * [`dateformat`](#-logrotate--conf--dateformat)
 * [`dateyesterday`](#-logrotate--conf--dateyesterday)
@@ -534,6 +538,38 @@ Data type: `Optional[String]`
 Default value: `undef`
 
 ##### <a name="-logrotate--conf--create_group"></a>`create_group`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+##### <a name="-logrotate--conf--createolddir"></a>`createolddir`
+
+Data type: `Optional[Boolean]`
+
+
+
+Default value: `undef`
+
+##### <a name="-logrotate--conf--createolddir_mode"></a>`createolddir_mode`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+##### <a name="-logrotate--conf--createolddir_owner"></a>`createolddir_owner`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+##### <a name="-logrotate--conf--createolddir_group"></a>`createolddir_group`
 
 Data type: `Optional[String]`
 
@@ -811,6 +847,14 @@ create_owner    - A username String that logrotate should set the owner of the
                   newly created log file to if create => true (optional).
 create_group    - A String group name that logrotate should apply to the newly
                   created log file if create => true (optional).
+createolddir    - A Boolean specifying whether logrotate should create the
+                  olddir directory if it does not exist (optional).
+createolddir_mode - An octal mode String logrotate should apply to the
+                  olddir directory if createolddir => true (optional).
+createolddir_owner - A username String that logrotate should set the owner
+                  of the olddir directory to if createolddir => true (optional).
+createolddir_group - A String group name that logrotate should apply to the
+                  olddir directory if createolddir => true (optional).
 dateext         - A Boolean specifying whether rotated log files should be
                   archived by adding a date extension rather just a number
                   (optional).
@@ -930,6 +974,10 @@ The following parameters are available in the `logrotate::rule` defined type:
 * [`create_mode`](#-logrotate--rule--create_mode)
 * [`create_owner`](#-logrotate--rule--create_owner)
 * [`create_group`](#-logrotate--rule--create_group)
+* [`createolddir`](#-logrotate--rule--createolddir)
+* [`createolddir_mode`](#-logrotate--rule--createolddir_mode)
+* [`createolddir_owner`](#-logrotate--rule--createolddir_owner)
+* [`createolddir_group`](#-logrotate--rule--createolddir_group)
 * [`dateext`](#-logrotate--rule--dateext)
 * [`dateformat`](#-logrotate--rule--dateformat)
 * [`dateyesterday`](#-logrotate--rule--dateyesterday)
@@ -1064,6 +1112,38 @@ Data type: `Optional[String]`
 Default value: `undef`
 
 ##### <a name="-logrotate--rule--create_group"></a>`create_group`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+##### <a name="-logrotate--rule--createolddir"></a>`createolddir`
+
+Data type: `Optional[Boolean]`
+
+
+
+Default value: `undef`
+
+##### <a name="-logrotate--rule--createolddir_mode"></a>`createolddir_mode`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+##### <a name="-logrotate--rule--createolddir_owner"></a>`createolddir_owner`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+##### <a name="-logrotate--rule--createolddir_group"></a>`createolddir_group`
 
 Data type: `Optional[String]`
 

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -20,6 +20,10 @@ define logrotate::conf (
   Optional[String] $create_mode                      = undef,
   Optional[String] $create_owner                     = undef,
   Optional[String] $create_group                     = undef,
+  Optional[Boolean] $createolddir                    = undef,
+  Optional[String] $createolddir_mode                = undef,
+  Optional[String] $createolddir_owner               = undef,
+  Optional[String] $createolddir_group               = undef,
   Optional[Boolean] $dateext                         = undef,
   Optional[String] $dateformat                       = undef,
   Optional[Boolean] $dateyesterday                   = undef,
@@ -79,6 +83,18 @@ define logrotate::conf (
 
   if $create_mode and !$create {
     fail("Logrotate::Conf[${name}]: create_mode requires create")
+  }
+
+  if $createolddir_group and !$createolddir_owner {
+    fail("Logrotate::Conf[${name}]: createolddir_group requires createolddir_owner")
+  }
+
+  if $createolddir_owner and !$createolddir_mode {
+    fail("Logrotate::Conf[${name}]: createolddir_owner requires createolddir_mode")
+  }
+
+  if $createolddir_mode and !$createolddir {
+    fail("Logrotate::Conf[${name}]: createolddir_mode requires createolddir")
   }
 
   #

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -24,6 +24,14 @@
 #                   newly created log file to if create => true (optional).
 # create_group    - A String group name that logrotate should apply to the newly
 #                   created log file if create => true (optional).
+# createolddir    - A Boolean specifying whether logrotate should create the
+#                   olddir directory if it does not exist (optional).
+# createolddir_mode - An octal mode String logrotate should apply to the
+#                   olddir directory if createolddir => true (optional).
+# createolddir_owner - A username String that logrotate should set the owner
+#                   of the olddir directory to if createolddir => true (optional).
+# createolddir_group - A String group name that logrotate should apply to the
+#                   olddir directory if createolddir => true (optional).
 # dateext         - A Boolean specifying whether rotated log files should be
 #                   archived by adding a date extension rather just a number
 #                   (optional).
@@ -139,6 +147,10 @@ define logrotate::rule (
   Optional[String] $create_mode                     = undef,
   Optional[String] $create_owner                    = undef,
   Optional[String] $create_group                    = undef,
+  Optional[Boolean] $createolddir                   = undef,
+  Optional[String] $createolddir_mode               = undef,
+  Optional[String] $createolddir_owner              = undef,
+  Optional[String] $createolddir_group              = undef,
   Optional[Boolean] $dateext                        = undef,
   Optional[String] $dateformat                      = undef,
   Optional[Boolean] $dateyesterday                  = undef,
@@ -211,6 +223,18 @@ define logrotate::rule (
 
   if ($create_mode != undef) and ($create != true) {
     fail("Logrotate::Rule[${rulename}]: create_mode requires create")
+  }
+
+  if ($createolddir_group != undef) and ($createolddir_owner == undef) {
+    fail("Logrotate::Rule[${rulename}]: createolddir_group requires createolddir_owner")
+  }
+
+  if ($createolddir_owner != undef) and ($createolddir_mode == undef) {
+    fail("Logrotate::Rule[${rulename}]: createolddir_owner requires createolddir_mode")
+  }
+
+  if ($createolddir_mode != undef) and ($createolddir != true) {
+    fail("Logrotate::Rule[${rulename}]: createolddir_mode requires createolddir")
   }
 
   #############################################################################

--- a/spec/defines/rule_spec.rb
+++ b/spec/defines/rule_spec.rb
@@ -309,6 +309,74 @@ describe 'logrotate::rule' do
     end
 
     ###########################################################################
+    # CREATEOLDDIR
+    context 'and createolddir => true' do
+      let(:params) { { path: '/var/log/foo.log', createolddir: true } }
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.d/test').
+          with_content(%r{^  createolddir$})
+      }
+    end
+
+    context 'and createolddir => false' do
+      let(:params) { { path: '/var/log/foo.log', createolddir: false } }
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.d/test').
+          with_content(%r{^  nocreateolddir$})
+      }
+    end
+
+    context 'and createolddir => true, createolddir_mode => 0755' do
+      let(:params) do
+        {
+          path: '/var/log/foo.log',
+          createolddir: true,
+          createolddir_mode: '0755'
+        }
+      end
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.d/test').
+          with_content(%r{^  createolddir 0755$})
+      }
+    end
+
+    context 'and createolddir => true, createolddir_mode => 0755, createolddir_owner => httpd' do
+      let(:params) do
+        {
+          path: '/var/log/foo.log',
+          createolddir: true,
+          createolddir_mode: '0755',
+          createolddir_owner: 'httpd'
+        }
+      end
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.d/test').
+          with_content(%r{^  createolddir 0755 httpd$})
+      }
+    end
+
+    context 'and createolddir => true, createolddir_mode => 0755, createolddir_owner => httpd, createolddir_group => www' do
+      let(:params) do
+        {
+          path: '/var/log/foo.log',
+          createolddir: true,
+          createolddir_mode: '0755',
+          createolddir_owner: 'httpd',
+          createolddir_group: 'www'
+        }
+      end
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.d/test').
+          with_content(%r{^  createolddir 0755 httpd www$})
+      }
+    end
+
+    ###########################################################################
     # POSTROTATE
     context 'and postrotate => /bin/true' do
       let(:params) do

--- a/templates/etc/logrotate.conf.erb
+++ b/templates/etc/logrotate.conf.erb
@@ -17,6 +17,14 @@
     opts << 'nocreate'
   end
 
+  if @createolddir
+    opts << ['createolddir', @createolddir_mode, @createolddir_owner, @createolddir_group].reject { |r|
+      r == nil
+    }.join(' ')
+  elsif @createolddir == false
+    opts << 'nocreateolddir'
+  end
+
   %w(compress copy copytruncate delaycompress
   dateext missingok sharedscripts shred dateyesterday).each do |bool_opt|
     if (scope.to_hash.has_key?(bool_opt) && scope.to_hash[bool_opt] != nil)

--- a/templates/etc/logrotate.d/rule.erb
+++ b/templates/etc/logrotate.d/rule.erb
@@ -18,6 +18,14 @@
     opts << 'nocreate'
   end
 
+  if @createolddir
+    opts << ['createolddir', @createolddir_mode, @createolddir_owner, @createolddir_group].reject { |r|
+      r == nil
+    }.join(' ')
+  elsif @createolddir == false
+    opts << 'nocreateolddir'
+  end
+
   %w(compress copy copytruncate delaycompress
   dateext missingok sharedscripts shred dateyesterday).each do |bool_opt|
     if (scope.to_hash.has_key?(bool_opt) && scope.to_hash[bool_opt] != nil)


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for the `createolddir` parameter.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-logrotate/issues/42
