### PR TITLE
Drop EOL Ubuntu 20.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04",
         "24.04"
       ]

--- a/spec/classes/defaults_spec.rb
+++ b/spec/classes/defaults_spec.rb
@@ -48,21 +48,12 @@ describe 'logrotate' do
     context os, if: os_facts['os']['name'] == 'Ubuntu' do
       let(:facts) { os_facts }
 
-      if os_facts['os']['release']['full'].to_i <= 18
-        it {
-          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
-            'su_user' => 'root',
-            'su_group' => 'syslog'
-          )
-        }
-      else
-        it {
-          is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
-            'su_user' => 'root',
-            'su_group' => 'adm'
-          )
-        }
-      end
+      it {
+        is_expected.to contain_logrotate__conf('/etc/logrotate.conf').with(
+          'su_user' => 'root',
+          'su_group' => 'adm'
+        )
+      }
     end
 
     context os, if: os_facts['os']['family'] == 'RedHat' do


### PR DESCRIPTION
#### Pull Request (PR) description

* Remove EOL Ubuntu 20.04
* Purge test conditions for Ubuntu <= 18

#### This Pull Request (PR) fixes the following issues

Fixes #266 
