### PR TITLE
add purge_configdir to hourly

### DIFF
--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -16,11 +16,13 @@ class logrotate::hourly (
   assert_private()
 
   file { "${logrotate::rules_configdir}/hourly":
-    ensure => 'directory',
-    owner  => $logrotate::root_user,
-    group  => $logrotate::root_group,
-    mode   => $logrotate::rules_configdir_mode,
-    force  => true,
+    ensure  => 'directory',
+    owner   => $logrotate::root_user,
+    group   => $logrotate::root_group,
+    mode    => $logrotate::rules_configdir_mode,
+    purge   => $logrotate::purge_configdir,
+    recurse => $logrotate::purge_configdir,
+    force   => true,
   }
 
   if $logrotate::manage_cron_hourly {


### PR DESCRIPTION
#### Pull Request (PR) description
Hourly config is now respecting the `purge_configdir` directive.

#### This Pull Request (PR) fixes the following issues
no issue was created.