### PR TITLE
Add `tabooext` and `taboopat` parameters to `logrotate.conf`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -323,6 +323,22 @@ logrotate::conf {
 }
 ```
 
+##### ignore only *.foo files
+
+```puppet
+logrotate::conf {
+  tabooext => '.foo'
+}
+```
+
+##### add *.foo and *.bar to ignored files, but still ignore defaults (.rpmsave for example)
+
+```puppet
+logrotate::conf {
+  tabooext => ['+','.foo','.bar'],
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `logrotate::conf` defined type:
@@ -366,6 +382,8 @@ The following parameters are available in the `logrotate::conf` defined type:
 * [`su`](#-logrotate--conf--su)
 * [`su_user`](#-logrotate--conf--su_user)
 * [`su_group`](#-logrotate--conf--su_group)
+* [`tabooext`](#-logrotate--conf--tabooext)
+* [`taboopat`](#-logrotate--conf--taboopat)
 * [`uncompresscmd`](#-logrotate--conf--uncompresscmd)
 * [`createolddir`](#-logrotate--conf--createolddir)
 * [`createolddir_mode`](#-logrotate--conf--createolddir_mode)
@@ -722,6 +740,26 @@ A String group name that logrotate should use to rotate a log file set
 instead of using the default if su => true.
 
 Default value: `'root'`
+
+##### <a name="-logrotate--conf--tabooext"></a>`tabooext`
+
+Data type: `Optional[Variant[String,Array[String[1]]]]`
+
+Ignore files whose names end with one of the taboo extensions
+If a + precedes the list of extensions, the current taboo
+extension list is augmented, otherwise it is replaced.
+
+Default value: `undef`
+
+##### <a name="-logrotate--conf--taboopat"></a>`taboopat`
+
+Data type: `Optional[Variant[String,Array[String[1]]]]`
+
+Ignore files whose names end with one of the taboo patterns
+If a + precedes the list of patterns, the current taboo pattern
+list is augmented, otherwise it is replaced.
+
+Default value: `undef`
 
 ##### <a name="-logrotate--conf--uncompresscmd"></a>`uncompresscmd`
 

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -155,6 +155,16 @@
 #   A String group name that logrotate should use to rotate a log file set
 #   instead of using the default if su => true.
 #
+# @param tabooext
+#   Ignore files whose names end with one of the taboo extensions
+#   If a + precedes the list of extensions, the current taboo
+#   extension list is augmented, otherwise it is replaced.
+#
+# @param taboopat
+#   Ignore files whose names end with one of the taboo patterns
+#   If a + precedes the list of patterns, the current taboo pattern
+#   list is augmented, otherwise it is replaced.
+#
 # @param uncompresscmd
 #   The String command to be used to uncompress log files.
 #
@@ -170,6 +180,16 @@
 #     compressext     => '.zst',
 #     compressoptions => '--compress -19',
 #     uncompresscmd   => '/usr/bin/unzstd',
+#   }
+#
+# @example ignore only *.foo files
+#   logrotate::conf {
+#     tabooext => '.foo'
+#   }
+#
+# @example add *.foo and *.bar to ignored files, but still ignore defaults (.rpmsave for example)
+#   logrotate::conf {
+#     tabooext => ['+','.foo','.bar'],
 #   }
 #
 define logrotate::conf (
@@ -217,6 +237,8 @@ define logrotate::conf (
   Boolean $su                                        = false,
   String $su_user                                    = 'root',
   String $su_group                                   = 'root',
+  Optional[Variant[String,Array[String[1]]]] $tabooext = undef,
+  Optional[Variant[String,Array[String[1]]]] $taboopat = undef,
   Optional[String] $uncompresscmd                    = undef
 ) {
   case $mail {

--- a/spec/defines/conf_spec.rb
+++ b/spec/defines/conf_spec.rb
@@ -457,6 +457,44 @@ describe 'logrotate::conf' do
       }
     end
 
+    # TABOOEXT
+    context 'tabooext => .foo' do
+      let(:params) { { tabooext: '.foo' } }
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.conf')
+          .with_content(%r{^tabooext \.foo$})
+      }
+    end
+
+    context 'tabooext => [+,.foo,.bar]' do
+      let(:params) { { tabooext: ['+', '.foo', '.bar'] } }
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.conf')
+          .with_content(%r{^tabooext \+ \.foo \.bar$})
+      }
+    end
+
+    # TABOOPAT
+    context 'taboopat => *foo*' do
+      let(:params) { { taboopat: '*foo*' } }
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.conf')
+          .with_content(%r{^taboopat \*foo\*$})
+      }
+    end
+
+    context 'taboopat => [+,*foo*,*bar*]' do
+      let(:params) { { taboopat: ['+', '*foo*', '*bar*'] } }
+
+      it {
+        is_expected.to contain_file('/etc/logrotate.conf')
+          .with_content(%r{^taboopat \+ \*foo\* \*bar\*$})
+      }
+    end
+
     # Boolean Flag values
     %w[compress copy copytruncate create dateext delaycompress ifempty missingok sharedscripts shred dateyesterday].each do |param|
       it_behaves_like 'boolean flag', param, param != 'create'

--- a/templates/etc/logrotate.conf.erb
+++ b/templates/etc/logrotate.conf.erb
@@ -45,6 +45,11 @@
     opts << "#{key} #{value}" if value != nil
   end
 
+  %w(tabooext taboopat).each do |key|
+    value = Array(scope.to_hash[key])
+    opts << "#{key} #{value.join(' ')}" if value != []
+  end
+
   Array(@include).compact.each do |path|
     opts << "include #{path}"
   end


### PR DESCRIPTION
#### Pull Request (PR) description
Add parameters `tabooext` and `taboopat` to config as documented in the man page (https://www.man7.org/linux/man-pages/man8/logrotate.8.html)

>tabooext [+] list
>   The current taboo extension list is changed (see the include directive for information on the taboo extensions). If a + precedes the list of extensions, the current taboo extension list is augmented, otherwise it is replaced. At startup, the taboo extension list  contains .rpmsave, .rpmorig, ~, .disabled, .dpkg-old, .dpkg-dist, .dpkg-new, .cfsaved, .ucf-old, .ucf-dist, .ucf-new, .rpmnew, .swp,  .cfsaved, .rhn-cfg-tmp-*
>
>taboopat [+] list
>     The current taboo glob pattern list is changed (see the include directive for information on the taboo extensions and patterns).  If a + precedes the list of patterns, the current taboo pattern list is augmented, otherwise it is replaced. At startup, the taboo pattern list is empty. 

#### This Pull Request (PR) fixes the following issues

